### PR TITLE
Feat parameter updater cherrypick

### DIFF
--- a/src/pdf_beamtime/README.md
+++ b/src/pdf_beamtime/README.md
@@ -17,11 +17,18 @@ ros2 service call /pdf_update_obstacles pdf_beamtime_interfaces/srv/UpdateObstac
 
 ## Service to add a new obstacle 
 name: new obstacle name
-type: BOX or CYLINDER
+type: BOX
 x, y, z: location for the obstacle
 w, h, d, r: width, height, depth, and radius 
 ```bash
-ros2 service call /pdf_new_obstacle pdf_beamtime_interfaces/srv/NewObstacleMsg '{name: "obstacle", type: "BOX", x: 1.5, y: 0.2, z: 0.9, w: 0.3, h: 0.3, d: 0.3, r: 0.0}'
+ros2 service call /pdf_new_box_obstacle pdf_beamtime_interfaces/srv/BoxObstacleMsg '{name: "obstacle", type: "BOX", x: 1.5, y: 0.2, z: 0.9, w: 0.3, h: 0.3, d: 0.3}'
+```
+
+type: CYLINDER
+x, y, z: location for the obstacle
+w, h, d, r: width, height, depth, and radius 
+```bash
+ros2 service call /pdf_new_cylinder_obstacle pdf_beamtime_interfaces/srv/CylinderObstacleMsg '{name: "obstacle2", type: "CYLINDER", x: 1.5, y: 0.2, z: 1.9, h: 0.3, r: 0.10}'
 ```
 
 ## Service to remove an obstacle 

--- a/src/pdf_beamtime/include/pdf_beamtime/pdf_beamtime_server.hpp
+++ b/src/pdf_beamtime/include/pdf_beamtime/pdf_beamtime_server.hpp
@@ -18,16 +18,18 @@ BSD 3 Clause License. See LICENSE.txt for details.*/
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp_action/rclcpp_action.hpp>
 #include <pdf_beamtime_interfaces/action/pick_place_control_msg.hpp>
-#include <pdf_beamtime_interfaces/srv/new_obstacle_msg.hpp>
 #include <pdf_beamtime_interfaces/srv/update_obstacle_msg.hpp>
 #include <pdf_beamtime_interfaces/srv/delete_obstacle_msg.hpp>
+#include <pdf_beamtime_interfaces/srv/box_obstacle_msg.hpp>
+#include <pdf_beamtime_interfaces/srv/cylinder_obstacle_msg.hpp>
 
 /// @brief Create the obstacle environment and an simple action server for the robot to move
 class PdfBeamtimeServer
 {
 public:
   using PickPlaceControlMsg = pdf_beamtime_interfaces::action::PickPlaceControlMsg;
-  using NewObstacleMsg = pdf_beamtime_interfaces::srv::NewObstacleMsg;
+  using BoxObstacleMsg = pdf_beamtime_interfaces::srv::BoxObstacleMsg;
+  using CylinderObstacleMsg = pdf_beamtime_interfaces::srv::CylinderObstacleMsg;
   using UpdateObstaclesMsg = pdf_beamtime_interfaces::srv::UpdateObstacleMsg;
   using DeleteObstacleMsg = pdf_beamtime_interfaces::srv::DeleteObstacleMsg;
 
@@ -44,7 +46,8 @@ private:
   /// @brief records the two types of obstacles CYLINDER and BOX.
   std::map<std::string, int> obstacle_type_map_;
 
-  rclcpp::Service<NewObstacleMsg>::SharedPtr env_refresh_service_;
+  rclcpp::Service<BoxObstacleMsg>::SharedPtr new_box_obstacle_service_;
+  rclcpp::Service<CylinderObstacleMsg>::SharedPtr new_cylinder_obstacle_service_;
   rclcpp::Service<UpdateObstaclesMsg>::SharedPtr update_obstacles_service_;
   rclcpp::Service<DeleteObstacleMsg>::SharedPtr remove_obstacles_service_;
 
@@ -72,12 +75,19 @@ private:
   /// @return a vector of CollisionObjects
   std::vector<moveit_msgs::msg::CollisionObject> create_env();
 
-  /// @brief Callback for adding a new obstacle
-  /// @param request a NewObstacleMsg
+  /// @brief Callback for adding a new box obstacle
+  /// @param request a BoxObstacleMsg
   /// @param response Success / Failure
-  void new_obstacle_service_cb(
-    const std::shared_ptr<NewObstacleMsg::Request> request,
-    std::shared_ptr<NewObstacleMsg::Response> response);
+  void new_box_obstacle_service_cb(
+    const std::shared_ptr<BoxObstacleMsg::Request> request,
+    std::shared_ptr<BoxObstacleMsg::Response> response);
+
+  /// @brief Callback for adding a new Cylinder obstacle
+  /// @param request a CylinderObstacleMsg
+  /// @param response Success / Failure
+  void new_cylinder_obstacle_service_cb(
+    const std::shared_ptr<CylinderObstacleMsg::Request> request,
+    std::shared_ptr<CylinderObstacleMsg::Response> response);
 
   /// @brief Callback for changing the value of an existing obstacle
   /// @param request UpdateObstaclesMsg

--- a/src/pdf_beamtime/src/pdf_beamtime_server.cpp
+++ b/src/pdf_beamtime/src/pdf_beamtime_server.cpp
@@ -3,6 +3,7 @@ BSD 3 Clause License. See LICENSE.txt for details.*/
 #include <pdf_beamtime/pdf_beamtime_server.hpp>
 
 using moveit::planning_interface::MoveGroupInterface;
+using namespace std::placeholders;
 
 PdfBeamtimeServer::PdfBeamtimeServer(
   const std::string & move_group_name = "ur_manipulator",
@@ -19,35 +20,30 @@ PdfBeamtimeServer::PdfBeamtimeServer(
   new_box_obstacle_service_ = node_->create_service<BoxObstacleMsg>(
     "pdf_new_box_obstacle",
     std::bind(
-      &PdfBeamtimeServer::new_box_obstacle_service_cb, this, std::placeholders::_1,
-      std::placeholders::_2
-  ));
+      &PdfBeamtimeServer::new_box_obstacle_service_cb, this, _1, _2));
 
   new_cylinder_obstacle_service_ = node_->create_service<CylinderObstacleMsg>(
     "pdf_new_cylinder_obstacle",
     std::bind(
-      &PdfBeamtimeServer::new_cylinder_obstacle_service_cb, this, std::placeholders::_1,
-      std::placeholders::_2));
+      &PdfBeamtimeServer::new_cylinder_obstacle_service_cb, this, _1, _2));
 
   update_obstacles_service_ = node_->create_service<UpdateObstaclesMsg>(
     "pdf_update_obstacles",
     std::bind(
-      &PdfBeamtimeServer::update_obstacles_service_cb, this, std::placeholders::_1,
-      std::placeholders::_2));
+      &PdfBeamtimeServer::update_obstacles_service_cb, this, _1, _2));
 
   remove_obstacles_service_ = node_->create_service<DeleteObstacleMsg>(
     "pdf_remove_obstacle",
     std::bind(
-      &PdfBeamtimeServer::remove_obstacles_service_cb, this, std::placeholders::_1,
-      std::placeholders::_2));
+      &PdfBeamtimeServer::remove_obstacles_service_cb, this, _1, _2));
 
   // Create the action server
   action_server_ = rclcpp_action::create_server<PickPlaceControlMsg>(
     this->node_,
     action_name,
-    std::bind(&PdfBeamtimeServer::handle_goal, this, std::placeholders::_1, std::placeholders::_2),
-    std::bind(&PdfBeamtimeServer::handle_cancel, this, std::placeholders::_1),
-    std::bind(&PdfBeamtimeServer::handle_accepted, this, std::placeholders::_1));
+    std::bind(&PdfBeamtimeServer::handle_goal, this, _1, _2),
+    std::bind(&PdfBeamtimeServer::handle_cancel, this, _1),
+    std::bind(&PdfBeamtimeServer::handle_accepted, this, _1));
 }
 rclcpp::node_interfaces::NodeBaseInterface::SharedPtr PdfBeamtimeServer::getNodeBaseInterface()
 // Expose the node base interface so that the node can be added to a component manager.

--- a/src/pdf_beamtime_interfaces/CMakeLists.txt
+++ b/src/pdf_beamtime_interfaces/CMakeLists.txt
@@ -12,9 +12,10 @@ find_package(rosidl_default_generators REQUIRED)
 # Generate interfaces for actions and services
 rosidl_generate_interfaces(${PROJECT_NAME}
   "action/PickPlaceControlMsg.action"
-  "srv/NewObstacleMsg.srv"
   "srv/UpdateObstacleMsg.srv"
   "srv/DeleteObstacleMsg.srv"
+  "srv/BoxObstacleMsg.srv"
+  "srv/CylinderObstacleMsg.srv"
 )
 
 

--- a/src/pdf_beamtime_interfaces/srv/BoxObstacleMsg.srv
+++ b/src/pdf_beamtime_interfaces/srv/BoxObstacleMsg.srv
@@ -6,6 +6,5 @@ float64 z
 float64 w 
 float64 h 
 float64 d 
-float64 r 
 ---
 string results

--- a/src/pdf_beamtime_interfaces/srv/CylinderObstacleMsg.srv
+++ b/src/pdf_beamtime_interfaces/srv/CylinderObstacleMsg.srv
@@ -1,0 +1,9 @@
+string name
+string type
+float64 x
+float64 y 
+float64 z 
+float64 h 
+float64 r 
+---
+string results


### PR DESCRIPTION
This fixes bug https://github.com/maffettone/erobs/issues/11 by adding two message types and two services for each obstacle type, Box and Cylinder.

Does so after cherry picking the relevant commits to clean up history. 