### PR TITLE
fix: incorrect xml foramt

### DIFF
--- a/docker/ur-driver/Dockerfile
+++ b/docker/ur-driver/Dockerfile
@@ -31,7 +31,7 @@ ENV ROBOT_IP=192.168.56.101
 ENV REVERSE_IP=192.168.56.102
 ENV UR_TYPE="ur3e"
 ENV DESCRIPTION_PKG="ur3e_hande_robot_description"
-ENV DESCRIPTION_FILE="ur_with_hande.urdf.xacro"
+ENV DESCRIPTION_FILE="ur_with_hande.xacro"
 
 # Copy entrypoint script
 COPY entrypoint.sh /entrypoint.sh

--- a/docker/ur-moveit/Dockerfile
+++ b/docker/ur-moveit/Dockerfile
@@ -37,7 +37,7 @@ ENV REVERSE_IP=192.168.56.102
 ENV UR_TYPE="ur3e"
 ENV LAUNCH_RVIZ="false"
 ENV DESCRIPTION_PKG="ur3e_hande_robot_description"
-ENV DESCRIPTION_FILE="ur_with_hande.urdf.xacro"
+ENV DESCRIPTION_FILE="ur_with_hande.xacro"
 ENV CONFIG_PKG="ur3e_hande_moveit_config"
 ENV CONFIG_FILE="ur.srdf"
 

--- a/src/ur3e_hande_robot_description/README.md
+++ b/src/ur3e_hande_robot_description/README.md
@@ -24,7 +24,7 @@ These files contains designs for the hand-e robot. .dae files are directly taken
 
 The description file for the hand-e gripper. This is inspired from *Acutronic Robotic*'s [robotiq_modular_gripper](https://github.com/AcutronicRobotics/robotiq_modular_gripper/blob/4e708524e5dd20753f711686eb2cd1017a25a09e/robotiq_hande_gripper_description/urdf/robotiq_hande.urdf.xacro) and extended to include paramters from config/hande. 
 
-**urdf/ur_with_hande.urdf.xacro**
+**urdf/ur_with_hande.xacro**
 
 This file creates the description for the ur3e robot and attaches the hande gripper. Ur3e robot module is created to be directly compatible with the humble version of the the package [ur_description](https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/blob/29e90d5095fdf4af99eba3c3eae153d7d5d769c0/urdf/ur.urdf.xacro) by the following line 
 ```xml

--- a/src/ur3e_hande_robot_description/urdf/hande.xacro
+++ b/src/ur3e_hande_robot_description/urdf/hande.xacro
@@ -1,7 +1,6 @@
-<!--Based on same file and version as the https://github.com/AcutronicRobotics/robotiq_modular_gripper/blob/4e708524e5dd20753f711686eb2cd1017a25a09e/robotiq_hande_gripper_description/urdf/robotiq_hande.urdf.xacro-->
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://wiki.ros.org/xacro" name="$(arg name)">
-
+<!--Based on same file and version as the https://github.com/AcutronicRobotics/robotiq_modular_gripper/blob/4e708524e5dd20753f711686eb2cd1017a25a09e/robotiq_hande_gripper_description/urdf/robotiq_hande.urdf.xacro-->
   <xacro:arg name="name" default="hande"/>
 
 <xacro:macro name="robotiq_hande" params="

--- a/src/ur3e_hande_robot_description/urdf/ur_with_hande.xacro
+++ b/src/ur3e_hande_robot_description/urdf/ur_with_hande.xacro
@@ -1,6 +1,6 @@
-<!--Based on same file and version as https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/blob/29e90d5095fdf4af99eba3c3eae153d7d5d769c0/urdf/ur.urdf.xacro-->
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://wiki.ros.org/xacro" name="$(arg name)">
+<!--Based on same file and version as https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/blob/29e90d5095fdf4af99eba3c3eae153d7d5d769c0/urdf/ur.urdf.xacro-->
    <!-- robot name parameter -->
    <xacro:arg name="name" default="ur"/>
    <!-- import main macro -->


### PR DESCRIPTION
Adding a comment at the beginning of .xacro files resulted in the following error:

Captured stderr output: XML parsing error: XML or text declaration not at start of entity: line 2, column 0
when processing file: /workspaces/erobs/install/ur3e_hande_robot_description/share/ur3e_hande_robot_description/urdf/ur_with_hande.xacro

Check that:
 - Your XML is well-formed
 - You have the xacro xmlns declaration: xmlns:xacro="http://www.ros.org/wiki/xacro"

Fix: The added comment was moved to line 3. 
Other fixes: The description file name was corrected from "ur_with_hande.urdf.xacro" to "ur_with_hande.xacro" in relevant Dockerfiles.