### PR TITLE
Humble bluesky fsm integration : Pause feature

### DIFF
--- a/src/pdf_beamtime/include/pdf_beamtime/pdf_beamtime_server.hpp
+++ b/src/pdf_beamtime/include/pdf_beamtime/pdf_beamtime_server.hpp
@@ -42,7 +42,7 @@ public:
     const std::string & move_group_name, const rclcpp::NodeOptions & options,
     std::string action_name);
   rclcpp::node_interfaces::NodeBaseInterface::SharedPtr getNodeBaseInterface();
-  rclcpp::node_interfaces::NodeBaseInterface::SharedPtr getNodeBaseInterface_BIN();
+  rclcpp::node_interfaces::NodeBaseInterface::SharedPtr getInterruptNodeBaseInterface();
 
 private:
   rclcpp::Node::SharedPtr node_;
@@ -121,9 +121,7 @@ private:
     const std::shared_ptr<DeleteObstacleMsg::Request> request,
     std::shared_ptr<DeleteObstacleMsg::Response> response);
 
-  void bluesky_interrupt_cb(
-    const std::shared_ptr<BlueskyInterruptMsg::Request> request,
-    std::shared_ptr<BlueskyInterruptMsg::Response> response);
+  void bluesky_interrupt_cb();
 
   /// @brief Callback for adding a new obstacle
   /// @param request a CylinderObstacleMsg or BoxObstacleMsg

--- a/src/pdf_beamtime/include/pdf_beamtime/pdf_beamtime_server.hpp
+++ b/src/pdf_beamtime/include/pdf_beamtime/pdf_beamtime_server.hpp
@@ -121,7 +121,12 @@ private:
     const std::shared_ptr<DeleteObstacleMsg::Request> request,
     std::shared_ptr<DeleteObstacleMsg::Response> response);
 
-  void bluesky_interrupt_cb();
+  /// @brief Callback to handle interrupts frm bluesky
+  /// @param request type of interrupt: int
+  /// @param response Success / Failure : bool
+  void bluesky_interrupt_cb(
+    const std::shared_ptr<BlueskyInterruptMsg::Request> request,
+    std::shared_ptr<BlueskyInterruptMsg::Response> response);
 
   /// @brief Callback for adding a new obstacle
   /// @param request a CylinderObstacleMsg or BoxObstacleMsg

--- a/src/pdf_beamtime/include/pdf_beamtime/pdf_beamtime_server.hpp
+++ b/src/pdf_beamtime/include/pdf_beamtime/pdf_beamtime_server.hpp
@@ -23,6 +23,7 @@ BSD 3 Clause License. See LICENSE.txt for details.*/
 #include <pdf_beamtime_interfaces/srv/delete_obstacle_msg.hpp>
 #include <pdf_beamtime_interfaces/srv/box_obstacle_msg.hpp>
 #include <pdf_beamtime_interfaces/srv/cylinder_obstacle_msg.hpp>
+#include <pdf_beamtime_interfaces/srv/bluesky_interrupt_msg.hpp>
 #include <pdf_beamtime/inner_state_machine.hpp>
 #include <pdf_beamtime/state_enum.hpp>
 
@@ -35,14 +36,17 @@ public:
   using CylinderObstacleMsg = pdf_beamtime_interfaces::srv::CylinderObstacleMsg;
   using UpdateObstaclesMsg = pdf_beamtime_interfaces::srv::UpdateObstacleMsg;
   using DeleteObstacleMsg = pdf_beamtime_interfaces::srv::DeleteObstacleMsg;
+  using BlueskyInterruptMsg = pdf_beamtime_interfaces::srv::BlueskyInterruptMsg;
 
   explicit PdfBeamtimeServer(
     const std::string & move_group_name, const rclcpp::NodeOptions & options,
     std::string action_name);
   rclcpp::node_interfaces::NodeBaseInterface::SharedPtr getNodeBaseInterface();
+  rclcpp::node_interfaces::NodeBaseInterface::SharedPtr getNodeBaseInterface_BIN();
 
 private:
   rclcpp::Node::SharedPtr node_;
+  rclcpp::Node::SharedPtr interrupt_node_;
 
   moveit::planning_interface::MoveGroupInterface move_group_interface_;
 
@@ -54,6 +58,7 @@ private:
   rclcpp::Service<CylinderObstacleMsg>::SharedPtr new_cylinder_obstacle_service_;
   rclcpp::Service<UpdateObstaclesMsg>::SharedPtr update_obstacles_service_;
   rclcpp::Service<DeleteObstacleMsg>::SharedPtr remove_obstacles_service_;
+  rclcpp::Service<BlueskyInterruptMsg>::SharedPtr bluesky_interrupt_service_;
 
   /// @brief Pointer to the action server
   rclcpp_action::Server<PickPlaceControlMsg>::SharedPtr action_server_;
@@ -115,6 +120,10 @@ private:
   void remove_obstacles_service_cb(
     const std::shared_ptr<DeleteObstacleMsg::Request> request,
     std::shared_ptr<DeleteObstacleMsg::Response> response);
+
+  void bluesky_interrupt_cb(
+    const std::shared_ptr<BlueskyInterruptMsg::Request> request,
+    std::shared_ptr<BlueskyInterruptMsg::Response> response);
 
   /// @brief Callback for adding a new obstacle
   /// @param request a CylinderObstacleMsg or BoxObstacleMsg

--- a/src/pdf_beamtime/src/bluesky_interrupt.py
+++ b/src/pdf_beamtime/src/bluesky_interrupt.py
@@ -1,3 +1,4 @@
+"""Copyright 2023 Brookhaven National Laboratory BSD 3 Clause License. See LICENSE.txt for details."""
 import rclpy
 from rclpy.node import Node
 
@@ -5,8 +6,10 @@ from pdf_beamtime_interfaces.srv import BlueskyInterruptMsg
 
 
 class BlueskyInterrupt(Node):
+    """Send a service request to the server."""
 
     def __init__(self):
+        """Create the client here."""
         super().__init__('bluesky_interrupt')
         self.cli = self.create_client(BlueskyInterruptMsg, 'bluesky_interrupt')
         while not self.cli.wait_for_service(timeout_sec=1.0):
@@ -14,6 +17,7 @@ class BlueskyInterrupt(Node):
         self.req = BlueskyInterruptMsg.Request()
 
     def send_request(self):
+        """Populate and the send the request."""
         self.req.interrupt_type = 1
         self.future = self.cli.call_async(self.req)
         rclpy.spin_until_future_complete(self, self.future)
@@ -21,6 +25,7 @@ class BlueskyInterrupt(Node):
 
 
 def main(args=None):
+    """Python main."""
     rclpy.init(args=args)
 
     minimal_client = BlueskyInterrupt()

--- a/src/pdf_beamtime/src/bluesky_interrupt.py
+++ b/src/pdf_beamtime/src/bluesky_interrupt.py
@@ -1,0 +1,33 @@
+import rclpy
+from rclpy.node import Node
+
+from pdf_beamtime_interfaces.srv import BlueskyInterruptMsg
+
+
+class BlueskyInterrupt(Node):
+
+    def __init__(self):
+        super().__init__('bluesky_interrupt')
+        self.cli = self.create_client(BlueskyInterruptMsg, 'bluesky_interrupt')
+        while not self.cli.wait_for_service(timeout_sec=1.0):
+            self.get_logger().info('service not available, waiting again...')
+        self.req = BlueskyInterruptMsg.Request()
+
+    def send_request(self):
+        self.future = self.cli.call_async(self.req)
+        rclpy.spin_until_future_complete(self, self.future)
+        return self.future.result()
+
+
+def main(args=None):
+    rclpy.init(args=args)
+
+    minimal_client = BlueskyInterrupt()
+    minimal_client.send_request()
+
+    minimal_client.destroy_node()
+    rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/src/pdf_beamtime/src/bluesky_interrupt.py
+++ b/src/pdf_beamtime/src/bluesky_interrupt.py
@@ -14,6 +14,7 @@ class BlueskyInterrupt(Node):
         self.req = BlueskyInterruptMsg.Request()
 
     def send_request(self):
+        self.req.interrupt_type = 1
         self.future = self.cli.call_async(self.req)
         rclpy.spin_until_future_complete(self, self.future)
         return self.future.result()

--- a/src/pdf_beamtime/src/pdf_beamtime_server.cpp
+++ b/src/pdf_beamtime/src/pdf_beamtime_server.cpp
@@ -59,9 +59,7 @@ PdfBeamtimeServer::PdfBeamtimeServer(
       &PdfBeamtimeServer::bluesky_interrupt_cb, this, _1, _2));
 }
 
-void PdfBeamtimeServer::bluesky_interrupt_cb(
-  const std::shared_ptr<BlueskyInterruptMsg::Request> request,
-  std::shared_ptr<BlueskyInterruptMsg::Response> response)
+void PdfBeamtimeServer::bluesky_interrupt_cb()
 {
   handle_pause();
 }
@@ -71,7 +69,8 @@ rclcpp::node_interfaces::NodeBaseInterface::SharedPtr PdfBeamtimeServer::getNode
   return node_->get_node_base_interface();
 }
 
-rclcpp::node_interfaces::NodeBaseInterface::SharedPtr PdfBeamtimeServer::getNodeBaseInterface_BIN()
+rclcpp::node_interfaces::NodeBaseInterface::SharedPtr PdfBeamtimeServer::
+getInterruptNodeBaseInterface()
 // Expose the node base interface of the bluesky interrupt node
 // so that the node can be added to a component manager.
 {
@@ -595,12 +594,12 @@ int main(int argc, char * argv[])
 
   rclcpp::executors::MultiThreadedExecutor executor;
 
-  auto parent_node = std::make_shared<PdfBeamtimeServer>(
+  auto beamtime_server = std::make_shared<PdfBeamtimeServer>(
     "ur_arm",
     node_options);
 
-  executor.add_node(parent_node->getNodeBaseInterface());
-  executor.add_node(parent_node->getNodeBaseInterface_BIN());
+  executor.add_node(beamtime_server->getNodeBaseInterface());
+  executor.add_node(beamtime_server->getInterruptNodeBaseInterface());
   executor.spin();
 
   rclcpp::shutdown();

--- a/src/pdf_beamtime/src/pdf_beamtime_server.cpp
+++ b/src/pdf_beamtime/src/pdf_beamtime_server.cpp
@@ -72,7 +72,8 @@ rclcpp::node_interfaces::NodeBaseInterface::SharedPtr PdfBeamtimeServer::getNode
 }
 
 rclcpp::node_interfaces::NodeBaseInterface::SharedPtr PdfBeamtimeServer::getNodeBaseInterface_BIN()
-// Expose the node base interface of the bluesky interrupt node so that the node can be added to a component manager.
+// Expose the node base interface of the bluesky interrupt node
+// so that the node can be added to a component manager.
 {
   return interrupt_node_->get_node_base_interface();
 }

--- a/src/pdf_beamtime/src/pdf_beamtime_server.cpp
+++ b/src/pdf_beamtime/src/pdf_beamtime_server.cpp
@@ -59,9 +59,21 @@ PdfBeamtimeServer::PdfBeamtimeServer(
       &PdfBeamtimeServer::bluesky_interrupt_cb, this, _1, _2));
 }
 
-void PdfBeamtimeServer::bluesky_interrupt_cb()
+void PdfBeamtimeServer::bluesky_interrupt_cb(
+  const std::shared_ptr<BlueskyInterruptMsg::Request> request,
+  std::shared_ptr<BlueskyInterruptMsg::Response> response)
 {
-  handle_pause();
+  switch (request->interrupt_type) {
+    case 1:
+      handle_pause();
+      response->results = true;
+      break;
+
+    default:
+      RCLCPP_ERROR(node_->get_logger(), "Incorrect interrput type");
+      response->results = false;
+      break;
+  }
 }
 rclcpp::node_interfaces::NodeBaseInterface::SharedPtr PdfBeamtimeServer::getNodeBaseInterface()
 // Expose the node base interface so that the node can be added to a component manager.

--- a/src/pdf_beamtime_interfaces/CMakeLists.txt
+++ b/src/pdf_beamtime_interfaces/CMakeLists.txt
@@ -16,6 +16,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "srv/DeleteObstacleMsg.srv"
   "srv/BoxObstacleMsg.srv"
   "srv/CylinderObstacleMsg.srv"
+  "srv/BlueskyInterruptMsg.srv"
 )
 
 

--- a/src/pdf_beamtime_interfaces/srv/BlueskyInterruptMsg.srv
+++ b/src/pdf_beamtime_interfaces/srv/BlueskyInterruptMsg.srv
@@ -1,0 +1,3 @@
+string name
+---
+string results

--- a/src/pdf_beamtime_interfaces/srv/BlueskyInterruptMsg.srv
+++ b/src/pdf_beamtime_interfaces/srv/BlueskyInterruptMsg.srv
@@ -1,3 +1,3 @@
-uint8 INTERRUPT_TYPE
+uint8 interrupt_type
 ---
 bool results

--- a/src/pdf_beamtime_interfaces/srv/BlueskyInterruptMsg.srv
+++ b/src/pdf_beamtime_interfaces/srv/BlueskyInterruptMsg.srv
@@ -1,3 +1,3 @@
-string name
+uint8 INTERRUPT_TYPE
 ---
-string results
+bool results


### PR DESCRIPTION
This PR implements the pause functionality of the finite state machine on the pdf_beamtime class. Two ROS2 nodes manage
1. an action server to execute a pick and place task, and 
2. a service to receive service requests that act as interrupts to the action server, and the interrupts map the [interrupts from Bluesky](https://blueskyproject.io/bluesky/state-machine.html)

Start the action server and the interrupt service:
`ros2 launch pdf_beamtime pdf_beamtime.launch.py  `

Launch the action client to start the pick and place task:
`python3 pdf_beamtime_client.py`

Launch to service client to send pause commands:
`python3 bluesky_interrupt.py
`

### Test results

Pause command is issued while the robot moves from state HOME to PICKUP_APPROACH:
https://github.com/maffettone/erobs/assets/125075309/fae5e032-4e54-4328-963a-a0a5d6a7a7a3

**expected terminal output**
[pdf_beamtime_server]: Set current state to HOME
[pdf_beamtime_server]: [HOME] Current state changed to HOME.
[pdf_beamtime_server]: Current state is state HOME.
[pdf_beamtime_server]: Executing state HOME
[pdf_beamtime_server]: Internal state changed from RESTING to MOVING 
[pdf_beamtime_server]: PAUSED command received
[pdf_beamtime_server]:  Paused while at internal state MOVING 
[pdf_beamtime_server]: Internal state changed from MOVING to PAUSED 
[move_group_interface]: Execute request aborted
[move_group_interface]: MoveGroupInterface::execute() failed or timeout reached

Pause command is issued while the robot moves from state GRASP_SUCCESS to PICKUP_RETREAT:
https://github.com/maffettone/erobs/assets/125075309/74e4a92e-21ba-4c39-84bf-8ef39606859b

**expected terminal output**
[pdf_beamtime_server]: Current state is state HOME.
[pdf_beamtime_server]: Executing state HOME
[move_group_interface]: Planning request complete!
[pdf_beamtime_server]: Internal state changed from RESTING to MOVING 
[pdf_beamtime_server]: [HOME] Current state changed to PICKUP_APPROACH.
[pdf_beamtime_server]: Internal state changed from MOVING to RESTING 
[pdf_beamtime_server]: Executing state PICKUP_APPROACH
[move_group_interface]: Planning request complete!
[pdf_beamtime_server]: Internal state changed from RESTING to MOVING 
[pdf_beamtime_server]: [PICKUP_APPROACH] Current state changed to PICKUP.
[pdf_beamtime_server]: Internal state changed from MOVING to RESTING 
[pdf_beamtime_server]: Executing state PICKUP
[pdf_beamtime_server]: [PICKUP] Current state changed to GRASP_SUCCESS.
[pdf_beamtime_server]: Executing state GRASP_SUCCESS
[move_group_interface]: Planning request complete!
[pdf_beamtime_server]: Internal state changed from RESTING to MOVING 
[pdf_beamtime_server]: PAUSED command received
[pdf_beamtime_server]:  Paused while at internal state MOVING 
[pdf_beamtime_server]: Internal state changed from MOVING to PAUSED 
[move_group_interface]: Execute request aborted
[move_group_interface]: MoveGroupInterface::execute() failed or timeout reached

Pause command is issued while the robot moves from state PICKUP_RETREAT to PLACE_APPROACH:
https://github.com/maffettone/erobs/assets/125075309/6a9eda52-b018-476d-89b1-17dd61d23740

**expected terminal output**
[pdf_beamtime_server]: Current state is state HOME.
[pdf_beamtime_server]: Executing state HOME
[pdf_beamtime_server]: Internal state changed from RESTING to MOVING 
[pdf_beamtime_server]: [HOME] Current state changed to PICKUP_APPROACH.
[pdf_beamtime_server]: Internal state changed from MOVING to RESTING 
[pdf_beamtime_server]: Executing state PICKUP_APPROACH
[pdf_beamtime_server]: Internal state changed from RESTING to MOVING 
[pdf_beamtime_server]: [PICKUP_APPROACH] Current state changed to PICKUP.
[pdf_beamtime_server]: Internal state changed from MOVING to RESTING 
[pdf_beamtime_server]: Executing state PICKUP
[pdf_beamtime_server]: [PICKUP] Current state changed to GRASP_SUCCESS. 
[pdf_beamtime_server]: Executing state GRASP_SUCCESS
[pdf_beamtime_server]: Internal state changed from RESTING to MOVING 
[pdf_beamtime_server]: [GRASP_SUCCESS] Current state changed to PICKUP_RETREAT.
[pdf_beamtime_server]: Internal state changed from MOVING to RESTING 
[pdf_beamtime_server]: Executing state PICKUP_RETREAT
[pdf_beamtime_server]: Internal state changed from RESTING to MOVING 
[pdf_beamtime_server]: PAUSED command received
[pdf_beamtime_server]:  Paused while at internal state MOVING 
[pdf_beamtime_server]: Internal state changed from MOVING to PAUSED 
[move_group_interface]: Execute request aborted
[move_group_interface]: MoveGroupInterface::execute() failed or timeout reached

Pause command is issued while the robot moves from state PLACE_RETREAT to HOME:
https://github.com/maffettone/erobs/assets/125075309/31fac2d7-9c12-496b-8a68-9e5c451ac407

**expected terminal output**
[pdf_beamtime_server]: Current state is state HOME.
[pdf_beamtime_server]: Executing state HOME
[pdf_beamtime_server]: Internal state changed from RESTING to MOVING 
[pdf_beamtime_server]: [HOME] Current state changed to PICKUP_APPROACH.
[pdf_beamtime_server]: Internal state changed from MOVING to RESTING 
[pdf_beamtime_server]: Executing state PICKUP_APPROACH
[pdf_beamtime_server]: Internal state changed from RESTING to MOVING 
[pdf_beamtime_server]: [PICKUP_APPROACH] Current state changed to PICKUP.
[pdf_beamtime_server]: Internal state changed from MOVING to RESTING 
[pdf_beamtime_server]: Executing state PICKUP
[pdf_beamtime_server]: [PICKUP] Current state changed to GRASP_SUCCESS. 
[pdf_beamtime_server]: Executing state GRASP_SUCCESS
[pdf_beamtime_server]: Internal state changed from RESTING to MOVING 
[pdf_beamtime_server]: [GRASP_SUCCESS] Current state changed to PICKUP_RETREAT.
[pdf_beamtime_server]: Internal state changed from MOVING to RESTING 
[pdf_beamtime_server]: Executing state PICKUP_RETREAT
[pdf_beamtime_server]: Internal state changed from RESTING to MOVING 
[pdf_beamtime_server]: [PICKUP_RETREAT] Current state changed to PLACE_APPROACH.
[pdf_beamtime_server]: Internal state changed from MOVING to RESTING 
[pdf_beamtime_server]: Executing state PLACE_APPROACH
[pdf_beamtime_server]: Internal state changed from RESTING to MOVING 
[pdf_beamtime_server]: [PLACE_APPROACH] Current state changed to PLACE.
[pdf_beamtime_server]: Internal state changed from MOVING to RESTING 
[pdf_beamtime_server]: Executing state PLACE
[pdf_beamtime_server]: [PLACE] Current state changed to RELEASE_SUCCESS. 
[pdf_beamtime_server]: Executing state RELEASE_SUCCESS
[pdf_beamtime_server]: Internal state changed from RESTING to MOVING 
[pdf_beamtime_server]: [RELEASE_SUCCESS] Current state changed to PLACE_RETREAT.
[pdf_beamtime_server]: Internal state changed from MOVING to RESTING 
[pdf_beamtime_server]: Executing state PLACE_RETREAT
[pdf_beamtime_server]: Internal state changed from RESTING to MOVING 
[pdf_beamtime_server]: PAUSED command received
[pdf_beamtime_server]:  Paused while at internal state MOVING 
[pdf_beamtime_server]: Internal state changed from MOVING to PAUSED 
[move_group_interface]: Execute request aborted
[move_group_interface]: MoveGroupInterface::execute() failed or timeout reached



