### PR TITLE
feat: stop, halt, and abort

### DIFF
--- a/src/pdf_beamtime/acceptance_tests/bluesky_interrupt_resume.py
+++ b/src/pdf_beamtime/acceptance_tests/bluesky_interrupt_resume.py
@@ -1,0 +1,56 @@
+"""Copyright 2023 Brookhaven National Laboratory BSD 3 Clause License. See LICENSE.txt for details."""
+import time
+
+import rclpy
+from rclpy.node import Node
+
+from pdf_beamtime_interfaces.srv import BlueskyInterruptMsg
+
+
+class BlueskyInterrupt(Node):
+    """Send a service request to the server."""
+
+    def __init__(self):
+        """Create the client here."""
+        super().__init__('bluesky_interrupt')
+        self.cli = self.create_client(BlueskyInterruptMsg, 'bluesky_interrupt')
+        while not self.cli.wait_for_service(timeout_sec=1.0):
+            self.get_logger().info('service not available, waiting again...')
+        self.req = BlueskyInterruptMsg.Request()
+
+    def send_pause_request(self):
+        """Populate and send the pause request."""
+        self.req.interrupt_type = 'PAUSE'
+        self.get_logger().info('Pause request sent')
+        self.future = self.cli.call_async(self.req)
+        rclpy.spin_until_future_complete(self, self.future)
+        return self.future.result()
+
+    def send_resume_request(self):
+        """Populate and send the resume request."""
+        self.req.interrupt_type = 'RESUME'
+        self.get_logger().info('Resume request sent')
+        self.future = self.cli.call_async(self.req)
+        rclpy.spin_until_future_complete(self, self.future)
+        return self.future.result()
+
+
+def main(args=None):
+    """Python main."""
+    rclpy.init(args=args)
+
+    minimal_client = BlueskyInterrupt()
+    pause_future_results = minimal_client.send_pause_request()
+    minimal_client.get_logger().info('Pause request results: ' + str(pause_future_results))
+
+    time.sleep(10.0)
+
+    resume_future_results = minimal_client.send_resume_request()
+    minimal_client.get_logger().info('Resume request results: ' + str(resume_future_results))
+
+    minimal_client.destroy_node()
+    rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/src/pdf_beamtime/acceptance_tests/bluesky_interrupt_resume.py
+++ b/src/pdf_beamtime/acceptance_tests/bluesky_interrupt_resume.py
@@ -13,8 +13,8 @@ class BlueskyInterrupt(Node):
     def __init__(self):
         """Create the client here."""
         super().__init__('bluesky_interrupt')
-        self.cli = self.create_client(BlueskyInterruptMsg, 'bluesky_interrupt')
-        while not self.cli.wait_for_service(timeout_sec=1.0):
+        self.client = self.create_client(BlueskyInterruptMsg, 'bluesky_interrupt')
+        while not self.client.wait_for_service(timeout_sec=1.0):
             self.get_logger().info('service not available, waiting again...')
         self.req = BlueskyInterruptMsg.Request()
 
@@ -22,7 +22,7 @@ class BlueskyInterrupt(Node):
         """Populate and send the pause request."""
         self.req.interrupt_type = 'PAUSE'
         self.get_logger().info('Pause request sent')
-        self.future = self.cli.call_async(self.req)
+        self.future = self.client.call_async(self.req)
         rclpy.spin_until_future_complete(self, self.future)
         return self.future.result()
 
@@ -30,7 +30,7 @@ class BlueskyInterrupt(Node):
         """Populate and send the resume request."""
         self.req.interrupt_type = 'RESUME'
         self.get_logger().info('Resume request sent')
-        self.future = self.cli.call_async(self.req)
+        self.future = self.client.call_async(self.req)
         rclpy.spin_until_future_complete(self, self.future)
         return self.future.result()
 

--- a/src/pdf_beamtime/acceptance_tests/bluesky_interrupt_stop.py
+++ b/src/pdf_beamtime/acceptance_tests/bluesky_interrupt_stop.py
@@ -19,7 +19,7 @@ class BlueskyInterrupt(Node):
         self.req = BlueskyInterruptMsg.Request()
 
     def send_pause_request(self):
-        """Populate and the send the pause request."""
+        """Populate and send the pause request."""
         self.req.interrupt_type = 'PAUSE'
         self.get_logger().info('Pause request sent')
         self.future = self.cli.call_async(self.req)
@@ -27,9 +27,33 @@ class BlueskyInterrupt(Node):
         return self.future.result()
 
     def send_resume_request(self):
-        """Populate and the send the resume request."""
+        """Populate and send the resume request."""
         self.req.interrupt_type = 'RESUME'
         self.get_logger().info('Resume request sent')
+        self.future = self.cli.call_async(self.req)
+        rclpy.spin_until_future_complete(self, self.future)
+        return self.future.result()
+
+    def send_stop_request(self):
+        """Populate and send the stop request."""
+        self.req.interrupt_type = 'STOP'
+        self.get_logger().info('Stop request sent')
+        self.future = self.cli.call_async(self.req)
+        rclpy.spin_until_future_complete(self, self.future)
+        return self.future.result()
+
+    def send_abort_request(self):
+        """Populate and send the abort request."""
+        self.req.interrupt_type = 'ABORT'
+        self.get_logger().info('Abort request sent')
+        self.future = self.cli.call_async(self.req)
+        rclpy.spin_until_future_complete(self, self.future)
+        return self.future.result()
+
+    def send_halt_request(self):
+        """Populate and send the halt request."""
+        self.req.interrupt_type = 'HALT'
+        self.get_logger().info('Halt request sent')
         self.future = self.cli.call_async(self.req)
         rclpy.spin_until_future_complete(self, self.future)
         return self.future.result()
@@ -43,9 +67,9 @@ def main(args=None):
     pause_future_results = minimal_client.send_pause_request()
     minimal_client.get_logger().info('Pause request results: ' + str(pause_future_results))
 
-    time.sleep(10.0)
+    time.sleep(2.0)
 
-    resume_future_results = minimal_client.send_resume_request()
+    resume_future_results = minimal_client.send_stop_request()
     minimal_client.get_logger().info('Resume request results: ' + str(resume_future_results))
 
     minimal_client.destroy_node()

--- a/src/pdf_beamtime/acceptance_tests/bluesky_interrupt_stop.py
+++ b/src/pdf_beamtime/acceptance_tests/bluesky_interrupt_stop.py
@@ -13,8 +13,8 @@ class BlueskyInterrupt(Node):
     def __init__(self):
         """Create the client here."""
         super().__init__('bluesky_interrupt')
-        self.cli = self.create_client(BlueskyInterruptMsg, 'bluesky_interrupt')
-        while not self.cli.wait_for_service(timeout_sec=1.0):
+        self.client = self.create_client(BlueskyInterruptMsg, 'bluesky_interrupt')
+        while not self.client.wait_for_service(timeout_sec=1.0):
             self.get_logger().info('service not available, waiting again...')
         self.req = BlueskyInterruptMsg.Request()
 
@@ -22,7 +22,7 @@ class BlueskyInterrupt(Node):
         """Populate and send the pause request."""
         self.req.interrupt_type = 'PAUSE'
         self.get_logger().info('Pause request sent')
-        self.future = self.cli.call_async(self.req)
+        self.future = self.client.call_async(self.req)
         rclpy.spin_until_future_complete(self, self.future)
         return self.future.result()
 
@@ -30,7 +30,7 @@ class BlueskyInterrupt(Node):
         """Populate and send the resume request."""
         self.req.interrupt_type = 'RESUME'
         self.get_logger().info('Resume request sent')
-        self.future = self.cli.call_async(self.req)
+        self.future = self.client.call_async(self.req)
         rclpy.spin_until_future_complete(self, self.future)
         return self.future.result()
 
@@ -38,7 +38,7 @@ class BlueskyInterrupt(Node):
         """Populate and send the stop request."""
         self.req.interrupt_type = 'STOP'
         self.get_logger().info('Stop request sent')
-        self.future = self.cli.call_async(self.req)
+        self.future = self.client.call_async(self.req)
         rclpy.spin_until_future_complete(self, self.future)
         return self.future.result()
 
@@ -46,7 +46,7 @@ class BlueskyInterrupt(Node):
         """Populate and send the abort request."""
         self.req.interrupt_type = 'ABORT'
         self.get_logger().info('Abort request sent')
-        self.future = self.cli.call_async(self.req)
+        self.future = self.client.call_async(self.req)
         rclpy.spin_until_future_complete(self, self.future)
         return self.future.result()
 
@@ -54,7 +54,7 @@ class BlueskyInterrupt(Node):
         """Populate and send the halt request."""
         self.req.interrupt_type = 'HALT'
         self.get_logger().info('Halt request sent')
-        self.future = self.cli.call_async(self.req)
+        self.future = self.client.call_async(self.req)
         rclpy.spin_until_future_complete(self, self.future)
         return self.future.result()
 

--- a/src/pdf_beamtime/include/pdf_beamtime/inner_state_machine.hpp
+++ b/src/pdf_beamtime/include/pdf_beamtime/inner_state_machine.hpp
@@ -44,13 +44,10 @@ public:
   void rewind();
 
   /// @brief  Set the state to abort. This follows a pause command.
-  void abort();
+  void abort(moveit::planning_interface::MoveGroupInterface & mgi);
 
   /// @brief  Set the state to halt. This follows a pause command.
-  void halt();
-
-  /// @brief  Set the state to Stop. This follows a pause command.
-  void stop();
+  void halt(moveit::planning_interface::MoveGroupInterface & mgi);
 
   /// @brief  Self explantory
   void set_internal_state(Internal_State state);

--- a/src/pdf_beamtime/include/pdf_beamtime/inner_state_machine.hpp
+++ b/src/pdf_beamtime/include/pdf_beamtime/inner_state_machine.hpp
@@ -21,11 +21,10 @@ private:
 
   std::vector<std::string> external_state_names_ =
   {"HOME", "PICKUP_APPROACH", "PICKUP", "GRASP_SUCCESS", "GRASP_FAILURE", "PICKUP_RETREAT",
-    "PLACE_APPROACH", "PLACE", "RELEASE_SUCCESS", "RELEASE_FAILURE", "PLACE_RETREAT",
-    "RETRY_PICKUP"};
+    "PLACE_APPROACH", "PLACE", "RELEASE_SUCCESS", "RELEASE_FAILURE", "PLACE_RETREAT"};
 
   std::vector<std::string> internal_state_names =
-  {"RESTING", "MOVING", "PAUSED", "ABORT", "HALT", "STOP"};
+  {"RESTING", "MOVING", "PAUSED", "ABORT", "HALT", "STOP", "CLEANUP"};
 
 public:
   explicit InnerStateMachine(const rclcpp::Node::SharedPtr node);

--- a/src/pdf_beamtime/include/pdf_beamtime/pdf_beamtime_server.hpp
+++ b/src/pdf_beamtime/include/pdf_beamtime/pdf_beamtime_server.hpp
@@ -153,12 +153,13 @@ private:
   /// @brief Set the current state to HOME and move robot to home position
   bool reset_fsm();
 
-  /// @brief Handles bluesky interrupt to PAUSE
+  /// @brief Handles bluesky interrupt to PAUSE, STOP, ABORT, and HALT
   void handle_pause();
   void handle_stop();
   void execute_stop();
   void handle_abort();
   void handle_halt();
+
   /// @brief Handles bluesky interrupt to RESUME
   void handle_resume();
 

--- a/src/pdf_beamtime/include/pdf_beamtime/pdf_beamtime_server.hpp
+++ b/src/pdf_beamtime/include/pdf_beamtime/pdf_beamtime_server.hpp
@@ -81,14 +81,17 @@ private:
 
   std::vector<std::string> external_state_names_ =
   {"HOME", "PICKUP_APPROACH", "PICKUP", "GRASP_SUCCESS", "GRASP_FAILURE", "PICKUP_RETREAT",
-    "PLACE_APPROACH", "PLACE", "RELEASE_SUCCESS", "RELEASE_FAILURE", "PLACE_RETREAT",
-    "RETRY_PICKUP"};
+    "PLACE_APPROACH", "PLACE", "RELEASE_SUCCESS", "RELEASE_FAILURE", "PLACE_RETREAT", "CLEAN_UP"};
 
   std::vector<std::string> internal_state_names =
-  {"RESTING", "MOVING", "PAUSED", "ABORT", "HALT", "STOP"};
+  {"RESTING", "MOVING", "PAUSED", "ABORT", "HALT", "STOP", "CLEANUP"};
 
   /// @brief current state of the robot
   State current_state_;
+
+  /// @brief holds the current goal to be used by return_sample() function
+  std::shared_ptr<const pdf_beamtime_interfaces::action::PickPlaceControlMsg_Goal> goal;
+
   /// @brief used to calculate the completion precentage
   const float total_states_ = 9.0;
   float progress_ = 0.0;
@@ -153,10 +156,14 @@ private:
   /// @brief Set the current state to HOME and move robot to home position
   bool reset_fsm();
 
+  /// @brief Put back the sample
+  moveit::core::MoveItErrorCode return_sample();
+
   /// @brief Handles bluesky interrupt to PAUSE, STOP, ABORT, and HALT
   void handle_pause();
   void handle_stop();
-  void execute_stop();
+  /// @brief returns the sample to where it was picked and ready robot to receive a new goal
+  void execute_cleanup();
   void handle_abort();
   void handle_halt();
 

--- a/src/pdf_beamtime/include/pdf_beamtime/pdf_beamtime_server.hpp
+++ b/src/pdf_beamtime/include/pdf_beamtime/pdf_beamtime_server.hpp
@@ -81,7 +81,7 @@ private:
 
   std::vector<std::string> external_state_names_ =
   {"HOME", "PICKUP_APPROACH", "PICKUP", "GRASP_SUCCESS", "GRASP_FAILURE", "PICKUP_RETREAT",
-    "PLACE_APPROACH", "PLACE", "RELEASE_SUCCESS", "RELEASE_FAILURE", "PLACE_RETREAT", "CLEAN_UP"};
+    "PLACE_APPROACH", "PLACE", "RELEASE_SUCCESS", "RELEASE_FAILURE", "PLACE_RETREAT"};
 
   std::vector<std::string> internal_state_names =
   {"RESTING", "MOVING", "PAUSED", "ABORT", "HALT", "STOP", "CLEANUP"};

--- a/src/pdf_beamtime/include/pdf_beamtime/pdf_beamtime_server.hpp
+++ b/src/pdf_beamtime/include/pdf_beamtime/pdf_beamtime_server.hpp
@@ -158,7 +158,7 @@ private:
   void handle_stop();
   void execute_stop();
   void handle_abort();
-
+  void handle_halt();
   /// @brief Handles bluesky interrupt to RESUME
   void handle_resume();
 

--- a/src/pdf_beamtime/include/pdf_beamtime/state_enum.hpp
+++ b/src/pdf_beamtime/include/pdf_beamtime/state_enum.hpp
@@ -4,7 +4,7 @@ BSD 3 Clause License. See LICENSE.txt for details.*/
 
 /// @brief States of the robot transitions
 enum class State {HOME, PICKUP_APPROACH, PICKUP, GRASP_SUCCESS, GRASP_FAILURE, PICKUP_RETREAT,
-  PLACE_APPROACH, PLACE, RELEASE_SUCCESS, RELEASE_FAILURE, PLACE_RETREAT, RETRY_PICKUP};
+  PLACE_APPROACH, PLACE, RELEASE_SUCCESS, RELEASE_FAILURE, PLACE_RETREAT, CLEAN_UP};
 
 /// @brief Internal states of the state machine
-enum class Internal_State {RESTING, MOVING, PAUSED, ABORT, HALT, STOP};
+enum class Internal_State {RESTING, MOVING, PAUSED, ABORT, HALT, STOP, CLEANUP};

--- a/src/pdf_beamtime/include/pdf_beamtime/state_enum.hpp
+++ b/src/pdf_beamtime/include/pdf_beamtime/state_enum.hpp
@@ -4,7 +4,7 @@ BSD 3 Clause License. See LICENSE.txt for details.*/
 
 /// @brief States of the robot transitions
 enum class State {HOME, PICKUP_APPROACH, PICKUP, GRASP_SUCCESS, GRASP_FAILURE, PICKUP_RETREAT,
-  PLACE_APPROACH, PLACE, RELEASE_SUCCESS, RELEASE_FAILURE, PLACE_RETREAT, CLEAN_UP};
+  PLACE_APPROACH, PLACE, RELEASE_SUCCESS, RELEASE_FAILURE, PLACE_RETREAT};
 
 /// @brief Internal states of the state machine
 enum class Internal_State {RESTING, MOVING, PAUSED, ABORT, HALT, STOP, CLEANUP};

--- a/src/pdf_beamtime/src/inner_state_machine.cpp
+++ b/src/pdf_beamtime/src/inner_state_machine.cpp
@@ -69,7 +69,7 @@ void InnerStateMachine::pause(moveit::planning_interface::MoveGroupInterface & m
     case Internal_State::MOVING:
       mgi.stop();
       RCLCPP_INFO(
-        node_->get_logger(), " Paused while at internal state %s ",
+        node_->get_logger(), "Paused while at internal state %s ",
         internal_state_names[static_cast<int>(internal_state_enum_)].c_str());
       set_internal_state(Internal_State::PAUSED);
       break;
@@ -78,19 +78,22 @@ void InnerStateMachine::pause(moveit::planning_interface::MoveGroupInterface & m
   }
 }
 
-void InnerStateMachine::abort()
+void InnerStateMachine::abort(moveit::planning_interface::MoveGroupInterface & mgi)
 {
+  mgi.stop();
+  RCLCPP_INFO(
+    node_->get_logger(), "Stopped while at internal state %s ",
+    internal_state_names[static_cast<int>(internal_state_enum_)].c_str());
   set_internal_state(Internal_State::ABORT);
 }
 
-void InnerStateMachine::halt()
+void InnerStateMachine::halt(moveit::planning_interface::MoveGroupInterface & mgi)
 {
+  mgi.stop();
+  RCLCPP_INFO(
+    node_->get_logger(), "Halted while at internal state %s ",
+    internal_state_names[static_cast<int>(internal_state_enum_)].c_str());
   set_internal_state(Internal_State::HALT);
-}
-
-void InnerStateMachine::stop()
-{
-  set_internal_state(Internal_State::STOP);
 }
 
 void InnerStateMachine::rewind()

--- a/src/pdf_beamtime/src/pdf_beamtime_server.cpp
+++ b/src/pdf_beamtime/src/pdf_beamtime_server.cpp
@@ -573,7 +573,6 @@ void PdfBeamtimeServer::execute_cleanup()
   reset_fsm();
   inner_state_machine_->set_internal_state(Internal_State::RESTING);
   RCLCPP_INFO(node_->get_logger(), "Cleanup is complete");
-
 }
 
 void PdfBeamtimeServer::handle_abort()

--- a/src/pdf_beamtime/src/pdf_beamtime_server.cpp
+++ b/src/pdf_beamtime/src/pdf_beamtime_server.cpp
@@ -156,7 +156,7 @@ void PdfBeamtimeServer::execute(
   feedback->status = get_action_completion_percentage();
 
   RCLCPP_INFO(
-    node_->get_logger(), "Current state is state %s.",
+    node_->get_logger(), "Current state is %s.",
     external_state_names_[static_cast<int>(current_state_)].c_str());
 
   // Reset inner_state_machine at new goal
@@ -546,7 +546,6 @@ void PdfBeamtimeServer::handle_stop()
 
 void PdfBeamtimeServer::execute_stop()
 {
-  ///@todo @ChandimaFernando This needs testing
   switch (current_state_) {
     case State::GRASP_SUCCESS:
       // handle the decision to pick up something else after successfully grabing the sample
@@ -568,6 +567,7 @@ void PdfBeamtimeServer::execute_stop()
       execute_stop();
       break;
 
+    /// @todo @ChandimaFernando This needs testing
     case State::PLACE:
       set_current_state(State::PICKUP_RETREAT);
       inner_state_machine_->set_internal_state(Internal_State::STOP);


### PR DESCRIPTION
***This PR implements Stop, Halt, and Abort functionalities.*** 

Below are the test results and the respective log outputs. 

**Halt**

https://github.com/maffettone/erobs/assets/125075309/ab987bc3-ba79-44da-99d0-a05e4134e52a

[pdf_beamtime_server]: [GRASP_SUCCESS] Current state changed to PICKUP_RETREAT.
[pdf_beamtime_server]: Internal state changed from MOVING to RESTING 
[pdf_beamtime_server]: Executing state PICKUP_RETREAT
[pdf_beamtime_server]: Internal state changed from RESTING to MOVING 
[pdf_beamtime_server]: PAUSED command received
[pdf_beamtime_server]: Paused while at internal state MOVING 
[pdf_beamtime_server]: Internal state changed from MOVING to PAUSED 
[move_group_interface]: Execute request aborted
[move_group_interface]: MoveGroupInterface::execute() failed or timeout reached
[pdf_beamtime_server]: HALT command received
[pdf_beamtime_server]: Halted while at internal state PAUSED 
[pdf_beamtime_server]: Internal state changed from PAUSED to HALT 
[pdf_beamtime_server]: Executing state PICKUP_RETREAT
[pdf_beamtime_server]: Robot's current internal state is HALT 
[pdf_beamtime_server]: Goal aborted !

**Stop /Abort at "PICKUP_RETREAT"**

In this test case, the robot pauses and stops at the state "PICKUP_RETREAT". Clean up action of returning the sample back to where it was picked and returning home take place. Current goal is cancelled. 

https://github.com/maffettone/erobs/assets/125075309/04c200cf-d0ca-4104-a1b1-3655217f6698

[pdf_beamtime_server]: Executing state PICKUP_RETREAT
[pdf_beamtime_server]: Internal state changed from RESTING to MOVING 
[pdf_beamtime_server]: PAUSED command received
[pdf_beamtime_server]: Paused while at internal state MOVING 
[pdf_beamtime_server]: Internal state changed from MOVING to PAUSED 
[pdf_beamtime_server]: STOP command received
[pdf_beamtime_server]: Internal state changed from PAUSED to CLEANUP 
[pdf_beamtime_server]: Cleanup is in progress
[pdf_beamtime_server]: Executing state PICKUP_RETREAT
[pdf_beamtime_server]: Goal aborted !
[pdf_beamtime_server]: [PICKUP_RETREAT] Current state changed to HOME.
[pdf_beamtime_server]: State machine was RESET
[pdf_beamtime_server]: Internal state changed from CLEANUP to RESTING 
[pdf_beamtime_server]: Cleanup is complete


**Stop at "PICKUP_APPROACH"**

In this test case, the robot pauses and stops at the state "PICKU_APPROACH". At clean up, goal is aborted and the robot is moved back to the home position before executing a new goal. 

https://github.com/maffettone/erobs/assets/125075309/55b78f04-309a-46c7-8896-925571faaa24

[pdf_beamtime_server]: Executing state HOME
[pdf_beamtime_server]: Internal state changed from RESTING to MOVING 
[pdf_beamtime_server]: PAUSED command received
[pdf_beamtime_server]: Paused while at internal state MOVING 
[pdf_beamtime_server]: Internal state changed from MOVING to PAUSED 
[pdf_beamtime_server]: STOP command received
[pdf_beamtime_server]: Internal state changed from PAUSED to CLEANUP 
[pdf_beamtime_server]: Cleanup is in progress
[pdf_beamtime_server]: Executing state HOME
[pdf_beamtime_server]: [HOME] Current state changed to HOME.
[pdf_beamtime_server]: State machine was RESET
[pdf_beamtime_server]: Internal state changed from CLEANUP to RESTING 
[pdf_beamtime_server]: Cleanup is complete
[pdf_beamtime_server]: Goal aborted !


