### PR TITLE
fix: correct ROBOT_MODEL in docker-compose.yml

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - 5900:5900
       - 6080:6080
     environment:
-      - ROBOT_MODEL=UR3e
+      - ROBOT_MODEL=UR3
     networks:
       ursim_net:
         ipv4_address: 192.168.56.101


### PR DESCRIPTION
This changes the ROBOT_MODEL environment variable from UR3e to UR3.
https://github.com/maffettone/erobs/blob/10a995f6d8e833f483279754cab07af7491666d4/docker/docker-compose.yml#L11
Reason: UR3e is an invalid argument for ROBOT_MODEL, hence it defaults to UR5.  Find the complete list of arguments [here](https://hub.docker.com/r/universalrobots/ursim_e-series)