### PR TITLE
Humble fiducial pose integration into pdf_beamtime

### DIFF
--- a/docker/erobs-common-img/README.md
+++ b/docker/erobs-common-img/README.md
@@ -52,6 +52,16 @@ podman run -it --rm --network host --ipc=host --pid=host \
 `tool_communication.py` should not be called when `ur_control.launch.py` is called, but separately when the gripper is initiated.  The 5s delay allows socat creation before running the gripper service. 
 The gripper_service has two convenience scripts, `gripper_open.cpp` and `gripper_close.cpp` that will start up client nodes to send a request to the gripper service then promptly shutdown the client nodes.
 
+# Launch aruco_pose 
+```bash
+podman run -it --network host --ipc=host --pid=host \
+    --env ROS_DISTRO=$ROS_DISTRO \
+    ${GHCR_POINTER} \
+    /bin/sh -c "printenv && \
+    . /root/ws/install/setup.sh && \
+    . /opt/ros/${ROS_DISTRO}/setup.sh && \
+    ros2 launch aruco_pose aruco_pose.launch.py"
+```
 
 # Launch move_group
 ```bash
@@ -66,16 +76,6 @@ podman run -it --rm --network host --ipc=host --pid=host \
     ${GHCR_POINTER} \
     /bin/sh -c "printenv && . /opt/ros/${ROS_DISTRO}/setup.sh && . /root/ws/install/setup.sh && ros2 launch ur_moveit_config ur_moveit.launch.py ur_type:=${UR_TYPE} launch_rviz:=${LAUNCH_RVIZ} description_package:=${DESCRIPTION_PKG}  launch_servo:=false description_file:=${DESCRIPTION_FILE} moveit_config_package:=${CONFIG_PKG} moveit_config_file:=${CONFIG_FILE}"
 ```
-# Launch aruco_pose 
-```bash
-podman run -it --network host --ipc=host --pid=host \
-    --env ROS_DISTRO=$ROS_DISTRO \
-    ${GHCR_POINTER} \
-    /bin/sh -c "printenv && \
-    . /root/ws/install/setup.sh && \
-    . /opt/ros/${ROS_DISTRO}/setup.sh && \
-    ros2 launch aruco_pose aruco_pose.launch.py"
-```
 
 # Launch the pdf_beamtime_server
 ```bash
@@ -83,6 +83,14 @@ podman run -it --network host --ipc=host --pid=host \
     --env ROS_DISTRO=$ROS_DISTRO \
     ${GHCR_POINTER} \
     /bin/sh -c "printenv && . /opt/ros/${ROS_DISTRO}/setup.sh && . /root/ws/install/setup.sh && ros2 launch pdf_beamtime pdf_beamtime.launch.py"
+```
+
+# Launch the pdf_beamtime_fidpose_server
+```bash
+podman run -it --network host --ipc=host --pid=host \
+    --env ROS_DISTRO=$ROS_DISTRO \
+    ${GHCR_POINTER} \
+    /bin/sh -c "printenv && . /opt/ros/${ROS_DISTRO}/setup.sh && . /root/ws/install/setup.sh && ros2 launch pdf_beamtime pdf_beamtime_fidpose_server.launch.py"
 ```
 
 # Test base rotation for Emergency stop

--- a/src/pdf_beamtime/CMakeLists.txt
+++ b/src/pdf_beamtime/CMakeLists.txt
@@ -13,6 +13,7 @@ find_package(pdf_beamtime_interfaces REQUIRED)
 find_package(rclcpp_action REQUIRED)
 find_package(rclcpp_components REQUIRED)
 find_package(yaml-cpp REQUIRED)
+find_package(geometry_msgs)
 
 set(dependencies
   moveit_ros_planning_interface
@@ -21,11 +22,12 @@ set(dependencies
   rclcpp_action
   rclcpp_components
   yaml-cpp
+  geometry_msgs
 )
 
 include_directories(include)  # This makes sure the libraries are visible
 
-add_executable(pdf_beamtime_server src/pdf_beamtime_server.cpp src/inner_state_machine.cpp)
+add_executable(pdf_beamtime_server src/pdf_beamtime_server.cpp src/inner_state_machine.cpp src/tf_utilities.cpp)
 ament_target_dependencies(pdf_beamtime_server ${dependencies})
 
 install(TARGETS

--- a/src/pdf_beamtime/CMakeLists.txt
+++ b/src/pdf_beamtime/CMakeLists.txt
@@ -27,11 +27,15 @@ set(dependencies
 
 include_directories(include)  # This makes sure the libraries are visible
 
-add_executable(pdf_beamtime_server src/pdf_beamtime_server.cpp src/inner_state_machine.cpp src/tf_utilities.cpp)
+add_executable(pdf_beamtime_server src/beamtime_entrypoint.cpp src/pdf_beamtime_server.cpp src/inner_state_machine.cpp)
 ament_target_dependencies(pdf_beamtime_server ${dependencies})
+
+add_executable(pdf_beamtime_fidpose_server src/pdf_beamtime_fidpose_server.cpp src/pdf_beamtime_server.cpp src/inner_state_machine.cpp src/tf_utilities.cpp)
+ament_target_dependencies(pdf_beamtime_fidpose_server ${dependencies})
 
 install(TARGETS
   pdf_beamtime_server
+  pdf_beamtime_fidpose_server
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION lib/${PROJECT_NAME}

--- a/src/pdf_beamtime/CMakeLists.txt
+++ b/src/pdf_beamtime/CMakeLists.txt
@@ -31,6 +31,7 @@ add_executable(pdf_beamtime_server src/beamtime_entrypoint.cpp src/pdf_beamtime_
 ament_target_dependencies(pdf_beamtime_server ${dependencies})
 
 add_executable(pdf_beamtime_fidpose_server
+    src/beamtime_fidpose_entrypoint.cpp
     src/pdf_beamtime_fidpose_server.cpp
     src/pdf_beamtime_server.cpp
     src/inner_state_machine.cpp

--- a/src/pdf_beamtime/CMakeLists.txt
+++ b/src/pdf_beamtime/CMakeLists.txt
@@ -30,7 +30,11 @@ include_directories(include)  # This makes sure the libraries are visible
 add_executable(pdf_beamtime_server src/beamtime_entrypoint.cpp src/pdf_beamtime_server.cpp src/inner_state_machine.cpp)
 ament_target_dependencies(pdf_beamtime_server ${dependencies})
 
-add_executable(pdf_beamtime_fidpose_server src/pdf_beamtime_fidpose_server.cpp src/pdf_beamtime_server.cpp src/inner_state_machine.cpp src/tf_utilities.cpp)
+add_executable(pdf_beamtime_fidpose_server 
+  src/pdf_beamtime_fidpose_server.cpp 
+  src/pdf_beamtime_server.cpp 
+  src/inner_state_machine.cpp 
+  src/tf_utilities.cpp)
 ament_target_dependencies(pdf_beamtime_fidpose_server ${dependencies})
 
 install(TARGETS

--- a/src/pdf_beamtime/CMakeLists.txt
+++ b/src/pdf_beamtime/CMakeLists.txt
@@ -30,11 +30,12 @@ include_directories(include)  # This makes sure the libraries are visible
 add_executable(pdf_beamtime_server src/beamtime_entrypoint.cpp src/pdf_beamtime_server.cpp src/inner_state_machine.cpp)
 ament_target_dependencies(pdf_beamtime_server ${dependencies})
 
-add_executable(pdf_beamtime_fidpose_server 
-  src/pdf_beamtime_fidpose_server.cpp 
-  src/pdf_beamtime_server.cpp 
-  src/inner_state_machine.cpp 
-  src/tf_utilities.cpp)
+add_executable(pdf_beamtime_fidpose_server
+    src/pdf_beamtime_fidpose_server.cpp
+    src/pdf_beamtime_server.cpp
+    src/inner_state_machine.cpp
+    src/tf_utilities.cpp
+)
 ament_target_dependencies(pdf_beamtime_fidpose_server ${dependencies})
 
 install(TARGETS

--- a/src/pdf_beamtime/config/joint_poses.yaml
+++ b/src/pdf_beamtime/config/joint_poses.yaml
@@ -1,4 +1,4 @@
 pdf_beamtime_server:
   ros__parameters:
-    home_angles: [0.0, -1.783732, 0.0, -1.75492, 0.0, 3.14159] #For real robot
+    home_angles: [-0.11536, -1.783732, 0.38816, -1.75492, 0.11484, 3.14159] #For real robot
     gripper_present: true

--- a/src/pdf_beamtime/config/joint_poses.yaml
+++ b/src/pdf_beamtime/config/joint_poses.yaml
@@ -1,4 +1,4 @@
 pdf_beamtime_server:
   ros__parameters:
-    home_angles: [-0.11536, -1.783732, 0.38816, -1.75492, 0.11484, 3.14159] #For real robot
+    home_angles: [0.0, -1.783732, 0.0, -1.75492, 0.0, 3.14159] #For real robot
     gripper_present: true

--- a/src/pdf_beamtime/config/joint_poses.yaml
+++ b/src/pdf_beamtime/config/joint_poses.yaml
@@ -1,5 +1,5 @@
 pdf_beamtime_server:
   ros__parameters:
     home_angles: [-0.11536, -1.783732, 0.38816, -1.75492, 0.11484, 3.14159] #For real robot
-    pickup_approach_angles: [5.1180035, -1.3447762, 2.08776285, -0.76043996, 2.09212617, 3.14159]
+    pickup_approach_angles: [5.1180035, -1.3447762, 2.08776285, -0.76043996, 3.48838958, 3.14159]
     gripper_present: true

--- a/src/pdf_beamtime/config/joint_poses.yaml
+++ b/src/pdf_beamtime/config/joint_poses.yaml
@@ -1,4 +1,5 @@
 pdf_beamtime_server:
   ros__parameters:
     home_angles: [-0.11536, -1.783732, 0.38816, -1.75492, 0.11484, 3.14159] #For real robot
+    pickup_approach_angles: [5.1180035, -1.3447762, 2.08776285, -0.76043996, 2.09212617, 3.14159]
     gripper_present: true

--- a/src/pdf_beamtime/include/pdf_beamtime/inner_state_machine.hpp
+++ b/src/pdf_beamtime/include/pdf_beamtime/inner_state_machine.hpp
@@ -17,9 +17,13 @@ class InnerStateMachine
 {
 private:
   rclcpp::Node::SharedPtr node_;
+  rclcpp::Node::SharedPtr gripper_node_;
+
   Internal_State internal_state_enum_;
   /// @brief Holds the passed joint target
   std::vector<double> joint_goal_;
+
+  rclcpp::Client<pdf_beamtime_interfaces::srv::GripperControlMsg>::SharedPtr gripper_client_;
 
   std::vector<std::string> external_state_names_ =
   {"HOME", "PICKUP_APPROACH", "PICKUP", "GRASP_SUCCESS", "GRASP_FAILURE", "PICKUP_RETREAT",
@@ -28,10 +32,10 @@ private:
   std::vector<std::string> internal_state_names =
   {"RESTING", "MOVING", "PAUSED", "ABORT", "HALT", "STOP", "CLEANUP"};
 
-  rclcpp::Client<pdf_beamtime_interfaces::srv::GripperControlMsg>::SharedPtr gripper_client_;
-
 public:
-  explicit InnerStateMachine(const rclcpp::Node::SharedPtr node);
+  explicit InnerStateMachine(
+    const rclcpp::Node::SharedPtr node,
+    const rclcpp::Node::SharedPtr gripper_node);
 
   /// @brief move the robot to the passed joint angles
   /// @param mgi move_group_interface_

--- a/src/pdf_beamtime/include/pdf_beamtime/inner_state_machine.hpp
+++ b/src/pdf_beamtime/include/pdf_beamtime/inner_state_machine.hpp
@@ -4,12 +4,14 @@ BSD 3 Clause License. See LICENSE.txt for details.*/
 
 #include <moveit/move_group_interface/move_group_interface.h>
 
+#include <chrono>
 #include <future>
 #include <string>
 #include <map>
 #include <vector>
 #include <rclcpp/node.hpp>
 #include <pdf_beamtime/state_enum.hpp>
+#include <pdf_beamtime_interfaces/srv/gripper_control_msg.hpp>
 
 class InnerStateMachine
 {
@@ -26,6 +28,8 @@ private:
   std::vector<std::string> internal_state_names =
   {"RESTING", "MOVING", "PAUSED", "ABORT", "HALT", "STOP", "CLEANUP"};
 
+  rclcpp::Client<pdf_beamtime_interfaces::srv::GripperControlMsg>::SharedPtr gripper_client_;
+
 public:
   explicit InnerStateMachine(const rclcpp::Node::SharedPtr node);
 
@@ -35,6 +39,10 @@ public:
   moveit::core::MoveItErrorCode move_robot(
     moveit::planning_interface::MoveGroupInterface & mgi,
     std::vector<double> joint_goal);
+
+  moveit::core::MoveItErrorCode move_robot_cartesian(
+    moveit::planning_interface::MoveGroupInterface & mgi,
+    std::vector<geometry_msgs::msg::Pose> target_pose);
 
   /// @brief state change if paused command was issues
   void pause(moveit::planning_interface::MoveGroupInterface & mgi);
@@ -52,8 +60,7 @@ public:
   void set_internal_state(Internal_State state);
   Internal_State get_internal_state();
 
-  /// @brief  Gripper object is not set at the pdf_beamtime level
-  /// @todo ChandimaFernando
+  /// @brief send client requests to open and close the gripper
   /// @return Moveit error code
   moveit::core::MoveItErrorCode open_gripper();
   moveit::core::MoveItErrorCode close_gripper();

--- a/src/pdf_beamtime/include/pdf_beamtime/pdf_beamtime_fidpose_server.hpp
+++ b/src/pdf_beamtime/include/pdf_beamtime/pdf_beamtime_fidpose_server.hpp
@@ -1,0 +1,120 @@
+/*Copyright 2024 Brookhaven National Laboratory
+BSD 3 Clause License. See LICENSE.txt for details.*/
+#pragma once
+
+#include <pdf_beamtime/pdf_beamtime_server.hpp>
+
+/// @brief Create the obstacle environment and an simple action server for the robot to move
+class PdfBeamtimeFidPoseServer : public PdfBeamtimeServer
+{
+public:
+  explicit PdfBeamtimeFidPoseServer(
+    const std::string & move_group_name, const rclcpp::NodeOptions & options,
+    std::string action_name);
+
+protected:
+  // void handle_accepted(
+  //   const std::shared_ptr<rclcpp_action::ServerGoalHandle<PickPlaceControlMsg>> goal_handle);
+  // rclcpp_action::GoalResponse handle_goal(
+  //   const rclcpp_action::GoalUUID & uuid,
+  //   std::shared_ptr<const PickPlaceControlMsg::Goal> goal);
+  // rclcpp_action::CancelResponse handle_cancel(
+  //   const std::shared_ptr<rclcpp_action::ServerGoalHandle<PickPlaceControlMsg>> goal_handle);
+
+  moveit::core::MoveItErrorCode run_fsm(
+    std::shared_ptr<const pdf_beamtime_interfaces::action::PickPlaceControlMsg_Goal> goal);
+
+//   std::vector<std::string> external_state_names_ =
+//   {"HOME", "PICKUP_APPROACH", "PICKUP", "GRASP_SUCCESS", "GRASP_FAILURE", "PICKUP_RETREAT",
+//     "PLACE_APPROACH", "PLACE", "RELEASE_SUCCESS", "RELEASE_FAILURE", "PLACE_RETREAT"};
+
+//   std::vector<std::string> internal_state_names =
+//   {"RESTING", "MOVING", "PAUSED", "ABORT", "HALT", "STOP", "CLEANUP"};
+
+//   /// @brief current state of the robot
+//   State current_state_;
+
+//   /// @brief holds the current goal to be used by return_sample() function
+//   std::shared_ptr<const pdf_beamtime_interfaces::action::PickPlaceControlMsg_Goal> goal;
+
+//   /// @brief used to calculate the completion precentage
+//   const float total_states_ = 9.0;
+//   float progress_ = 0.0;
+
+// /// @todo @ChandimaFernando Implement to see if gripper is attached
+//   bool gripper_present_ = false;
+
+//   // Action server related callbacks
+//   rclcpp_action::GoalResponse handle_goal(
+//     const rclcpp_action::GoalUUID & uuid,
+//     std::shared_ptr<const PickPlaceControlMsg::Goal> goal);
+
+//   rclcpp_action::CancelResponse handle_cancel(
+//     const std::shared_ptr<rclcpp_action::ServerGoalHandle<PickPlaceControlMsg>> goal_handle);
+
+//   void handle_accepted(
+//     const std::shared_ptr<rclcpp_action::ServerGoalHandle<PickPlaceControlMsg>> goal_handle);
+
+//   virtual void execute(
+//     const std::shared_ptr<rclcpp_action::ServerGoalHandle<PickPlaceControlMsg>> goal_handle);
+
+//   /// @brief generates a vector of obstacles from a yaml file.
+//   /// @return a vector of CollisionObjects
+//   std::vector<moveit_msgs::msg::CollisionObject> create_env();
+
+//   /// @brief Callback for changing the value of an existing obstacle
+//   /// @param request UpdateObstaclesMsg
+//   /// @param response Success / Failure
+//   void update_obstacles_service_cb(
+//     const std::shared_ptr<UpdateObstaclesMsg::Request> request,
+//     std::shared_ptr<UpdateObstaclesMsg::Response> response);
+
+//   /// @brief Callback to remove an existing obstacle
+//   /// @param request DeleteObstacleMsg
+//   /// @param response Success / Failure
+//   void remove_obstacles_service_cb(
+//     const std::shared_ptr<DeleteObstacleMsg::Request> request,
+//     std::shared_ptr<DeleteObstacleMsg::Response> response);
+
+//   /// @brief Callback to handle interrupts frm bluesky
+//   /// @param request type of interrupt: int
+//   /// @param response Success / Failure : bool
+//   void bluesky_interrupt_cb(
+//     const std::shared_ptr<BlueskyInterruptMsg::Request> request,
+//     std::shared_ptr<BlueskyInterruptMsg::Response> response);
+
+//   /// @brief Callback for adding a new obstacle
+//   /// @param request a CylinderObstacleMsg or BoxObstacleMsg
+//   /// @param response Success / Failure
+//   template<typename RequestT, typename ResponseT>
+//   void new_obstacle_service_cb(
+//     const typename RequestT::SharedPtr request,
+//     typename ResponseT::SharedPtr response);
+
+//   /// @brief Set the current state to the next state
+//   float get_action_completion_percentage();
+
+//   /// @brief Performs the transitions for each State
+//   moveit::core::MoveItErrorCode run_fsm(
+//     std::shared_ptr<const pdf_beamtime_interfaces::action::PickPlaceControlMsg_Goal> goal);
+
+//   /// @brief Set the current state to HOME and move robot to home position
+//   bool reset_fsm();
+
+//   /// @brief Put back the sample
+//   moveit::core::MoveItErrorCode return_sample();
+
+//   /// @brief Handles bluesky interrupt to PAUSE, STOP, ABORT, and HALT
+//   void handle_pause();
+//   void handle_stop();
+//   /// @brief returns the sample to where it was picked and ready robot to receive a new goal
+//   void execute_cleanup();
+//   void handle_abort();
+//   void handle_halt();
+
+//   /// @brief Handles bluesky interrupt to RESUME
+//   void handle_resume();
+
+//   /// @brief change the current state here
+//   void set_current_state(State state);
+};

--- a/src/pdf_beamtime/include/pdf_beamtime/pdf_beamtime_fidpose_server.hpp
+++ b/src/pdf_beamtime/include/pdf_beamtime/pdf_beamtime_fidpose_server.hpp
@@ -3,6 +3,7 @@ BSD 3 Clause License. See LICENSE.txt for details.*/
 #pragma once
 
 #include <pdf_beamtime/pdf_beamtime_server.hpp>
+#include <pdf_beamtime/tf_utilities.hpp>
 
 /// @brief Create the obstacle environment and an simple action server for the robot to move
 class PdfBeamtimeFidPoseServer : public PdfBeamtimeServer
@@ -13,108 +14,11 @@ public:
     std::string action_name);
 
 protected:
-  // void handle_accepted(
-  //   const std::shared_ptr<rclcpp_action::ServerGoalHandle<PickPlaceControlMsg>> goal_handle);
-  // rclcpp_action::GoalResponse handle_goal(
-  //   const rclcpp_action::GoalUUID & uuid,
-  //   std::shared_ptr<const PickPlaceControlMsg::Goal> goal);
-  // rclcpp_action::CancelResponse handle_cancel(
-  //   const std::shared_ptr<rclcpp_action::ServerGoalHandle<PickPlaceControlMsg>> goal_handle);
-
   moveit::core::MoveItErrorCode run_fsm(
     std::shared_ptr<const pdf_beamtime_interfaces::action::PickPlaceControlMsg_Goal> goal);
 
-//   std::vector<std::string> external_state_names_ =
-//   {"HOME", "PICKUP_APPROACH", "PICKUP", "GRASP_SUCCESS", "GRASP_FAILURE", "PICKUP_RETREAT",
-//     "PLACE_APPROACH", "PLACE", "RELEASE_SUCCESS", "RELEASE_FAILURE", "PLACE_RETREAT"};
-
-//   std::vector<std::string> internal_state_names =
-//   {"RESTING", "MOVING", "PAUSED", "ABORT", "HALT", "STOP", "CLEANUP"};
-
-//   /// @brief current state of the robot
-//   State current_state_;
-
-//   /// @brief holds the current goal to be used by return_sample() function
-//   std::shared_ptr<const pdf_beamtime_interfaces::action::PickPlaceControlMsg_Goal> goal;
-
-//   /// @brief used to calculate the completion precentage
-//   const float total_states_ = 9.0;
-//   float progress_ = 0.0;
-
-// /// @todo @ChandimaFernando Implement to see if gripper is attached
-//   bool gripper_present_ = false;
-
-//   // Action server related callbacks
-//   rclcpp_action::GoalResponse handle_goal(
-//     const rclcpp_action::GoalUUID & uuid,
-//     std::shared_ptr<const PickPlaceControlMsg::Goal> goal);
-
-//   rclcpp_action::CancelResponse handle_cancel(
-//     const std::shared_ptr<rclcpp_action::ServerGoalHandle<PickPlaceControlMsg>> goal_handle);
-
-//   void handle_accepted(
-//     const std::shared_ptr<rclcpp_action::ServerGoalHandle<PickPlaceControlMsg>> goal_handle);
-
-//   virtual void execute(
-//     const std::shared_ptr<rclcpp_action::ServerGoalHandle<PickPlaceControlMsg>> goal_handle);
-
-//   /// @brief generates a vector of obstacles from a yaml file.
-//   /// @return a vector of CollisionObjects
-//   std::vector<moveit_msgs::msg::CollisionObject> create_env();
-
-//   /// @brief Callback for changing the value of an existing obstacle
-//   /// @param request UpdateObstaclesMsg
-//   /// @param response Success / Failure
-//   void update_obstacles_service_cb(
-//     const std::shared_ptr<UpdateObstaclesMsg::Request> request,
-//     std::shared_ptr<UpdateObstaclesMsg::Response> response);
-
-//   /// @brief Callback to remove an existing obstacle
-//   /// @param request DeleteObstacleMsg
-//   /// @param response Success / Failure
-//   void remove_obstacles_service_cb(
-//     const std::shared_ptr<DeleteObstacleMsg::Request> request,
-//     std::shared_ptr<DeleteObstacleMsg::Response> response);
-
-//   /// @brief Callback to handle interrupts frm bluesky
-//   /// @param request type of interrupt: int
-//   /// @param response Success / Failure : bool
-//   void bluesky_interrupt_cb(
-//     const std::shared_ptr<BlueskyInterruptMsg::Request> request,
-//     std::shared_ptr<BlueskyInterruptMsg::Response> response);
-
-//   /// @brief Callback for adding a new obstacle
-//   /// @param request a CylinderObstacleMsg or BoxObstacleMsg
-//   /// @param response Success / Failure
-//   template<typename RequestT, typename ResponseT>
-//   void new_obstacle_service_cb(
-//     const typename RequestT::SharedPtr request,
-//     typename ResponseT::SharedPtr response);
-
-//   /// @brief Set the current state to the next state
-//   float get_action_completion_percentage();
-
-//   /// @brief Performs the transitions for each State
-//   moveit::core::MoveItErrorCode run_fsm(
-//     std::shared_ptr<const pdf_beamtime_interfaces::action::PickPlaceControlMsg_Goal> goal);
-
-//   /// @brief Set the current state to HOME and move robot to home position
-//   bool reset_fsm();
-
-//   /// @brief Put back the sample
-//   moveit::core::MoveItErrorCode return_sample();
-
-//   /// @brief Handles bluesky interrupt to PAUSE, STOP, ABORT, and HALT
-//   void handle_pause();
-//   void handle_stop();
-//   /// @brief returns the sample to where it was picked and ready robot to receive a new goal
-//   void execute_cleanup();
-//   void handle_abort();
-//   void handle_halt();
-
-//   /// @brief Handles bluesky interrupt to RESUME
-//   void handle_resume();
-
-//   /// @brief change the current state here
-//   void set_current_state(State state);
+private:
+  /// @brief Pointer to the inner state machine object
+  TFUtilities * tf_utilities_;
+  std::vector<double, std::allocator<double>> adjusted_pickup_;
 };

--- a/src/pdf_beamtime/include/pdf_beamtime/pdf_beamtime_fidpose_server.hpp
+++ b/src/pdf_beamtime/include/pdf_beamtime/pdf_beamtime_fidpose_server.hpp
@@ -2,6 +2,10 @@
 BSD 3 Clause License. See LICENSE.txt for details.*/
 #pragma once
 
+#include <memory>
+#include <string>
+#include <vector>
+
 #include <pdf_beamtime/pdf_beamtime_server.hpp>
 #include <pdf_beamtime/tf_utilities.hpp>
 

--- a/src/pdf_beamtime/include/pdf_beamtime/pdf_beamtime_fidpose_server.hpp
+++ b/src/pdf_beamtime/include/pdf_beamtime/pdf_beamtime_fidpose_server.hpp
@@ -8,25 +8,47 @@ BSD 3 Clause License. See LICENSE.txt for details.*/
 
 #include <pdf_beamtime/pdf_beamtime_server.hpp>
 #include <pdf_beamtime/tf_utilities.hpp>
+#include <pdf_beamtime_interfaces/action/fid_pose_control_msg.hpp>
 
 /// @brief Create the obstacle environment and an simple action server for the robot to move
 class PdfBeamtimeFidPoseServer : public PdfBeamtimeServer
 {
 public:
+  using FidPoseControlMsg = pdf_beamtime_interfaces::action::FidPoseControlMsg;
+
   explicit PdfBeamtimeFidPoseServer(
     const std::string & move_group_name, const rclcpp::NodeOptions & options,
     std::string action_name);
 
-protected:
-  moveit::core::MoveItErrorCode run_fsm(
-    std::shared_ptr<const pdf_beamtime_interfaces::action::PickPlaceControlMsg_Goal> goal);
-
 private:
+  moveit::core::MoveItErrorCode run_fsm(
+    std::shared_ptr<const pdf_beamtime_interfaces::action::FidPoseControlMsg_Goal> goal);
+
   /// @brief Pointer to the inner state machine object
   TFUtilities * tf_utilities_;
   std::vector<double, std::allocator<double>> adjusted_pickup_;
   std::vector<double, std::allocator<double>> adjusted_place_;
 
+  /// @brief holds the current goal to be used by return_sample() function
+  std::shared_ptr<const pdf_beamtime_interfaces::action::FidPoseControlMsg_Goal> fidpose_goal;
+
+  rclcpp_action::Server<FidPoseControlMsg>::SharedPtr fidpose_action_server_;
+
+  void fidpose_handle_accepted(
+    const std::shared_ptr<rclcpp_action::ServerGoalHandle<FidPoseControlMsg>> goal_handle);
+  rclcpp_action::GoalResponse fidpose_handle_goal(
+    const rclcpp_action::GoalUUID & uuid,
+    std::shared_ptr<const FidPoseControlMsg::Goal> goal);
+  rclcpp_action::CancelResponse fidpose_handle_cancel(
+    const std::shared_ptr<rclcpp_action::ServerGoalHandle<FidPoseControlMsg>> goal_handle);
+
+  virtual void execute(
+    const std::shared_ptr<rclcpp_action::ServerGoalHandle<FidPoseControlMsg>> goal_handle);
+
   moveit::core::MoveItErrorCode return_sample();
   void execute_cleanup();
+
+  bool pickup_pose_saved = false;
+  std::vector<double> pickup_approach_joints_;
+  std::vector<double> pickup_joints_;
 };

--- a/src/pdf_beamtime/include/pdf_beamtime/pdf_beamtime_fidpose_server.hpp
+++ b/src/pdf_beamtime/include/pdf_beamtime/pdf_beamtime_fidpose_server.hpp
@@ -21,4 +21,8 @@ private:
   /// @brief Pointer to the inner state machine object
   TFUtilities * tf_utilities_;
   std::vector<double, std::allocator<double>> adjusted_pickup_;
+  std::vector<double, std::allocator<double>> adjusted_place_;
+
+  moveit::core::MoveItErrorCode return_sample();
+  void execute_cleanup();
 };

--- a/src/pdf_beamtime/include/pdf_beamtime/pdf_beamtime_fidpose_server.hpp
+++ b/src/pdf_beamtime/include/pdf_beamtime/pdf_beamtime_fidpose_server.hpp
@@ -24,6 +24,9 @@ private:
   moveit::core::MoveItErrorCode run_fsm(
     std::shared_ptr<const pdf_beamtime_interfaces::action::FidPoseControlMsg_Goal> goal);
 
+  moveit::core::MoveItErrorCode run_return_fsm(
+    std::shared_ptr<const pdf_beamtime_interfaces::action::FidPoseControlMsg_Goal> goal);
+
   /// @brief Pointer to the inner state machine object
   TFUtilities * tf_utilities_;
   std::vector<double, std::allocator<double>> adjusted_pickup_;
@@ -31,6 +34,9 @@ private:
 
   /// @brief holds the current goal to be used by return_sample() function
   std::shared_ptr<const pdf_beamtime_interfaces::action::FidPoseControlMsg_Goal> fidpose_goal;
+
+  /// @brief records pickup approach state
+  std::vector<double, std::allocator<double>> pickup_approach_;
 
   rclcpp_action::Server<FidPoseControlMsg>::SharedPtr fidpose_action_server_;
 
@@ -49,6 +55,6 @@ private:
   void execute_cleanup();
 
   bool pickup_pose_saved = false;
-  std::vector<double> pickup_approach_joints_;
+  std::vector<double> pre_pickup_approach_joints_;
   std::vector<double> pickup_joints_;
 };

--- a/src/pdf_beamtime/include/pdf_beamtime/pdf_beamtime_server.hpp
+++ b/src/pdf_beamtime/include/pdf_beamtime/pdf_beamtime_server.hpp
@@ -59,7 +59,6 @@ protected:
   virtual moveit::core::MoveItErrorCode run_fsm(
     std::shared_ptr<const pdf_beamtime_interfaces::action::PickPlaceControlMsg_Goal> goal);
 
-private:
   rclcpp::Node::SharedPtr interrupt_node_;
 
   moveit::planning_interface::MoveGroupInterface move_group_interface_;

--- a/src/pdf_beamtime/include/pdf_beamtime/pdf_beamtime_server.hpp
+++ b/src/pdf_beamtime/include/pdf_beamtime/pdf_beamtime_server.hpp
@@ -44,8 +44,22 @@ public:
   rclcpp::node_interfaces::NodeBaseInterface::SharedPtr getNodeBaseInterface();
   rclcpp::node_interfaces::NodeBaseInterface::SharedPtr getInterruptNodeBaseInterface();
 
-private:
+protected:
   rclcpp::Node::SharedPtr node_;
+  /// @brief Pointer to the action server
+  rclcpp_action::Server<PickPlaceControlMsg>::SharedPtr action_server_;
+
+  virtual void handle_accepted(
+    const std::shared_ptr<rclcpp_action::ServerGoalHandle<PickPlaceControlMsg>> goal_handle);
+  // Action server related callbacks
+  virtual void execute(
+    const std::shared_ptr<rclcpp_action::ServerGoalHandle<PickPlaceControlMsg>> goal_handle);
+
+  /// @brief Performs the transitions for each State
+  virtual moveit::core::MoveItErrorCode run_fsm(
+    std::shared_ptr<const pdf_beamtime_interfaces::action::PickPlaceControlMsg_Goal> goal);
+
+private:
   rclcpp::Node::SharedPtr interrupt_node_;
 
   moveit::planning_interface::MoveGroupInterface move_group_interface_;
@@ -60,8 +74,6 @@ private:
   rclcpp::Service<DeleteObstacleMsg>::SharedPtr remove_obstacles_service_;
   rclcpp::Service<BlueskyInterruptMsg>::SharedPtr bluesky_interrupt_service_;
 
-  /// @brief Pointer to the action server
-  rclcpp_action::Server<PickPlaceControlMsg>::SharedPtr action_server_;
 
   /// @brief Pointer to the inner state machine object
   InnerStateMachine * inner_state_machine_;
@@ -99,20 +111,6 @@ private:
 /// @todo @ChandimaFernando Implement to see if gripper is attached
   bool gripper_present_ = false;
 
-  // Action server related callbacks
-  rclcpp_action::GoalResponse handle_goal(
-    const rclcpp_action::GoalUUID & uuid,
-    std::shared_ptr<const PickPlaceControlMsg::Goal> goal);
-
-  rclcpp_action::CancelResponse handle_cancel(
-    const std::shared_ptr<rclcpp_action::ServerGoalHandle<PickPlaceControlMsg>> goal_handle);
-
-  void handle_accepted(
-    const std::shared_ptr<rclcpp_action::ServerGoalHandle<PickPlaceControlMsg>> goal_handle);
-
-  void execute(
-    const std::shared_ptr<rclcpp_action::ServerGoalHandle<PickPlaceControlMsg>> goal_handle);
-
   /// @brief generates a vector of obstacles from a yaml file.
   /// @return a vector of CollisionObjects
   std::vector<moveit_msgs::msg::CollisionObject> create_env();
@@ -149,9 +147,15 @@ private:
   /// @brief Set the current state to the next state
   float get_action_completion_percentage();
 
-  /// @brief Performs the transitions for each State
-  moveit::core::MoveItErrorCode run_fsm(
-    std::shared_ptr<const pdf_beamtime_interfaces::action::PickPlaceControlMsg_Goal> goal);
+  rclcpp_action::GoalResponse handle_goal(
+    const rclcpp_action::GoalUUID & uuid,
+    std::shared_ptr<const PickPlaceControlMsg::Goal> goal);
+  rclcpp_action::CancelResponse handle_cancel(
+    const std::shared_ptr<rclcpp_action::ServerGoalHandle<PickPlaceControlMsg>> goal_handle);
+
+  // /// @brief Performs the transitions for each State
+  // moveit::core::MoveItErrorCode run_fsm(
+  //   std::shared_ptr<const pdf_beamtime_interfaces::action::PickPlaceControlMsg_Goal> goal);
 
   /// @brief Set the current state to HOME and move robot to home position
   bool reset_fsm();

--- a/src/pdf_beamtime/include/pdf_beamtime/pdf_beamtime_server.hpp
+++ b/src/pdf_beamtime/include/pdf_beamtime/pdf_beamtime_server.hpp
@@ -160,13 +160,13 @@ protected:
   bool reset_fsm();
 
   /// @brief Put back the sample
-  moveit::core::MoveItErrorCode return_sample();
+  virtual moveit::core::MoveItErrorCode return_sample();
 
   /// @brief Handles bluesky interrupt to PAUSE, STOP, ABORT, and HALT
   void handle_pause();
   void handle_stop();
   /// @brief returns the sample to where it was picked and ready robot to receive a new goal
-  void execute_cleanup();
+  virtual void execute_cleanup();
   void handle_abort();
   void handle_halt();
 

--- a/src/pdf_beamtime/include/pdf_beamtime/pdf_beamtime_server.hpp
+++ b/src/pdf_beamtime/include/pdf_beamtime/pdf_beamtime_server.hpp
@@ -24,6 +24,7 @@ BSD 3 Clause License. See LICENSE.txt for details.*/
 #include <pdf_beamtime_interfaces/srv/box_obstacle_msg.hpp>
 #include <pdf_beamtime_interfaces/srv/cylinder_obstacle_msg.hpp>
 #include <pdf_beamtime_interfaces/srv/bluesky_interrupt_msg.hpp>
+#include <pdf_beamtime_interfaces/srv/gripper_control_msg.hpp>
 #include <pdf_beamtime/inner_state_machine.hpp>
 #include <pdf_beamtime/state_enum.hpp>
 
@@ -60,6 +61,9 @@ protected:
     std::shared_ptr<const pdf_beamtime_interfaces::action::PickPlaceControlMsg_Goal> goal);
 
   rclcpp::Node::SharedPtr interrupt_node_;
+
+  // A separate node for the gripper
+  rclcpp::Node::SharedPtr gripper_node_;
 
   moveit::planning_interface::MoveGroupInterface move_group_interface_;
 

--- a/src/pdf_beamtime/include/pdf_beamtime/tf_utilities.hpp
+++ b/src/pdf_beamtime/include/pdf_beamtime/tf_utilities.hpp
@@ -2,24 +2,42 @@
 BSD 3 Clause License. See LICENSE.txt for details.*/
 #pragma once
 
+#include <moveit/move_group_interface/move_group_interface.h>
+#include <moveit/planning_scene_interface/planning_scene_interface.h>
+
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
-#include <geometry_msgs/msg/transform_stamped.hpp>
+#include <tf2/LinearMath/Quaternion.h>
+#include <tf2/LinearMath/Matrix3x3.h>
 
+#include <geometry_msgs/msg/transform_stamped.hpp>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#include <rclcpp/rclcpp.hpp>
 #include <rclcpp/node.hpp>
+#include <utility>
 
 class TFUtilities
 {
 private:
   rclcpp::Node::SharedPtr node_;
-
+  rclcpp::Logger tf_util_logger_;
   std::shared_ptr<tf2_ros::TransformListener> tf_listener_{nullptr};
   std::unique_ptr<tf2_ros::Buffer> tf_buffer_;
+
+  std::shared_ptr<rclcpp::SyncParametersClient> parameters_client_;
+
+  std::string world_frame, sample_frame, grasping_point_on_gripper_frame, wrist_2_frame,
+    pre_pickup_approach_point_frame;
 
 public:
   explicit TFUtilities(const rclcpp::Node::SharedPtr node);
 
   /// @brief converts degrees to radians
   double degreesToRadians(double degrees);
-  double get_elbow_alignment();
+
+  std::pair<double, double> get_wrist_elbow_alignment(
+    moveit::planning_interface::MoveGroupInterface & mgi);
+
+  std::vector<geometry_msgs::msg::Pose> get_pickup_action_waypoints(
+    moveit::planning_interface::MoveGroupInterface & mgi);
 };

--- a/src/pdf_beamtime/include/pdf_beamtime/tf_utilities.hpp
+++ b/src/pdf_beamtime/include/pdf_beamtime/tf_utilities.hpp
@@ -38,6 +38,14 @@ public:
   std::pair<double, double> get_wrist_elbow_alignment(
     moveit::planning_interface::MoveGroupInterface & mgi);
 
-  std::vector<geometry_msgs::msg::Pose> get_pickup_action_waypoints(
+  std::vector<geometry_msgs::msg::Pose> get_pickup_action_z_adj(
     moveit::planning_interface::MoveGroupInterface & mgi);
+
+  std::vector<geometry_msgs::msg::Pose> get_pickup_action_pre_pickup(
+    moveit::planning_interface::MoveGroupInterface & mgi);
+
+  std::vector<geometry_msgs::msg::Pose> get_pickup_action_pickup(
+    moveit::planning_interface::MoveGroupInterface & mgi);
+
+
 };

--- a/src/pdf_beamtime/include/pdf_beamtime/tf_utilities.hpp
+++ b/src/pdf_beamtime/include/pdf_beamtime/tf_utilities.hpp
@@ -4,11 +4,14 @@ BSD 3 Clause License. See LICENSE.txt for details.*/
 
 #include <moveit/move_group_interface/move_group_interface.h>
 #include <moveit/planning_scene_interface/planning_scene_interface.h>
-
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 #include <tf2/LinearMath/Quaternion.h>
 #include <tf2/LinearMath/Matrix3x3.h>
+
+#include <string>
+#include <memory>
+#include <vector>
 
 #include <geometry_msgs/msg/transform_stamped.hpp>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
@@ -46,6 +49,4 @@ public:
 
   std::vector<geometry_msgs::msg::Pose> get_pickup_action_pickup(
     moveit::planning_interface::MoveGroupInterface & mgi);
-
-
 };

--- a/src/pdf_beamtime/include/pdf_beamtime/tf_utilities.hpp
+++ b/src/pdf_beamtime/include/pdf_beamtime/tf_utilities.hpp
@@ -12,12 +12,12 @@ BSD 3 Clause License. See LICENSE.txt for details.*/
 #include <string>
 #include <memory>
 #include <vector>
+#include <utility>
 
 #include <geometry_msgs/msg/transform_stamped.hpp>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp/node.hpp>
-#include <utility>
 
 class TFUtilities
 {

--- a/src/pdf_beamtime/include/pdf_beamtime/tf_utilities.hpp
+++ b/src/pdf_beamtime/include/pdf_beamtime/tf_utilities.hpp
@@ -1,0 +1,25 @@
+/*Copyright 2024 Brookhaven National Laboratory
+BSD 3 Clause License. See LICENSE.txt for details.*/
+#pragma once
+
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/transform_listener.h>
+#include <geometry_msgs/msg/transform_stamped.hpp>
+
+#include <rclcpp/node.hpp>
+
+class TFUtilities
+{
+private:
+  rclcpp::Node::SharedPtr node_;
+
+  std::shared_ptr<tf2_ros::TransformListener> tf_listener_{nullptr};
+  std::unique_ptr<tf2_ros::Buffer> tf_buffer_;
+
+public:
+  explicit TFUtilities(const rclcpp::Node::SharedPtr node);
+
+  /// @brief converts degrees to radians
+  double degreesToRadians(double degrees);
+  double get_elbow_alignment();
+};

--- a/src/pdf_beamtime/launch/pdf_beamtime.launch.py
+++ b/src/pdf_beamtime/launch/pdf_beamtime.launch.py
@@ -8,7 +8,8 @@ def generate_launch_description():
     """Launch the node obstacle_builder with a parameter file."""
     action_cmd = Node(
         package="pdf_beamtime",
-        executable="pdf_beamtime_server",
+        # executable="pdf_beamtime_server",
+        executable="pdf_beamtime_fidpose_server",
         parameters=[
             PathJoinSubstitution([FindPackageShare("pdf_beamtime"), "config", "obstacles.yaml"]),
             PathJoinSubstitution([FindPackageShare("pdf_beamtime"), "config", "joint_poses.yaml"]),

--- a/src/pdf_beamtime/launch/pdf_beamtime_fidpose_server.launch.py
+++ b/src/pdf_beamtime/launch/pdf_beamtime_fidpose_server.launch.py
@@ -8,7 +8,7 @@ def generate_launch_description():
     """Launch the node obstacle_builder with a parameter file."""
     action_cmd = Node(
         package="pdf_beamtime",
-        executable="pdf_beamtime_server",
+        executable="pdf_beamtime_fidpose_server",
         parameters=[
             PathJoinSubstitution([FindPackageShare("pdf_beamtime"), "config", "obstacles.yaml"]),
             PathJoinSubstitution([FindPackageShare("pdf_beamtime"), "config", "joint_poses.yaml"]),

--- a/src/pdf_beamtime/src/beamtime_entrypoint.cpp
+++ b/src/pdf_beamtime/src/beamtime_entrypoint.cpp
@@ -1,0 +1,51 @@
+/*Copyright 2024 Brookhaven National Laboratory
+BSD 3 Clause License. See LICENSE.txt for details.*/
+#include <pdf_beamtime/pdf_beamtime_server.hpp>
+
+int main(int argc, char * argv[])
+{
+  rclcpp::init(argc, argv);
+
+  // Create a ROS logger for main scope
+  auto const logger = rclcpp::get_logger("hello_moveit");
+  using namespace std::chrono_literals;
+
+  // Create a node for synchronously grabbing params
+  auto parameter_client_node = rclcpp::Node::make_shared("param_client");
+  auto parent_parameters_client =
+    std::make_shared<rclcpp::SyncParametersClient>(parameter_client_node, "move_group");
+  // Boiler plate wait block
+  while (!parent_parameters_client->wait_for_service(1s)) {
+    if (!rclcpp::ok()) {
+      RCLCPP_ERROR(
+        logger, "Interrupted while waiting for the service. Exiting.");
+      return 0;
+    }
+    RCLCPP_INFO(logger, "move_group service not available, waiting again...");
+  }
+  // Get robot config parameters from parameter server
+  auto parameters = parent_parameters_client->get_parameters(
+    {"robot_description_semantic",
+      "robot_description"});
+
+  // Set node parameters using NodeOptions
+  rclcpp::NodeOptions node_options;
+  node_options.automatically_declare_parameters_from_overrides(true);
+  node_options.parameter_overrides(
+  {
+    {"robot_description_semantic", parameters[0].value_to_string()},
+    {"robot_description", parameters[1].value_to_string()}
+  });
+
+  rclcpp::executors::MultiThreadedExecutor executor;
+
+  auto beamtime_server = std::make_shared<PdfBeamtimeServer>(
+    "ur_arm", node_options, "pdf_beamtime_action_server");
+
+  executor.add_node(beamtime_server->getNodeBaseInterface());
+  executor.add_node(beamtime_server->getInterruptNodeBaseInterface());
+  executor.spin();
+
+  rclcpp::shutdown();
+  return 0;
+}

--- a/src/pdf_beamtime/src/beamtime_fidpose_entrypoint.cpp
+++ b/src/pdf_beamtime/src/beamtime_fidpose_entrypoint.cpp
@@ -1,0 +1,53 @@
+/*Copyright 2024 Brookhaven National Laboratory
+BSD 3 Clause License. See LICENSE.txt for details.*/
+#include <pdf_beamtime/pdf_beamtime_fidpose_server.hpp>
+
+int main(int argc, char * argv[])
+{
+  rclcpp::init(argc, argv);
+
+  // Create a ROS logger for main scope
+  auto const logger = rclcpp::get_logger("hello_moveit");
+  using namespace std::chrono_literals;
+
+  // Create a node for synchronously grabbing params
+  auto parameter_client_node = rclcpp::Node::make_shared("param_client");
+  auto parent_parameters_client =
+    std::make_shared<rclcpp::SyncParametersClient>(parameter_client_node, "move_group");
+  // Boiler plate wait block
+  while (!parent_parameters_client->wait_for_service(1s)) {
+    if (!rclcpp::ok()) {
+      RCLCPP_ERROR(
+        logger, "Interrupted while waiting for the service. Exiting.");
+      return 0;
+    }
+    RCLCPP_INFO(logger, "move_group service not available, waiting again...");
+  }
+  // Get robot config parameters from parameter server
+  auto parameters = parent_parameters_client->get_parameters(
+    {"robot_description_semantic",
+      "robot_description"});
+
+  // Set node parameters using NodeOptions
+  rclcpp::NodeOptions node_options;
+  node_options.automatically_declare_parameters_from_overrides(true);
+  node_options.parameter_overrides(
+  {
+    {"robot_description_semantic", parameters[0].value_to_string()},
+    {"robot_description", parameters[1].value_to_string()}
+  });
+
+  rclcpp::executors::MultiThreadedExecutor executor;
+
+  auto beamtime_server = std::make_shared<PdfBeamtimeFidPoseServer>(
+    "ur_arm",
+    node_options,
+    "pdf_beamtime_fidpose_action_server");
+
+  executor.add_node(beamtime_server->getNodeBaseInterface());
+  executor.add_node(beamtime_server->getInterruptNodeBaseInterface());
+  executor.spin();
+
+  rclcpp::shutdown();
+  return 0;
+}

--- a/src/pdf_beamtime/src/inner_state_machine.cpp
+++ b/src/pdf_beamtime/src/inner_state_machine.cpp
@@ -2,11 +2,17 @@
 BSD 3 Clause License. See LICENSE.txt for details.*/
 #include <pdf_beamtime/inner_state_machine.hpp>
 
+using namespace std::chrono_literals;
+
 InnerStateMachine::InnerStateMachine(
   const rclcpp::Node::SharedPtr node)
 : node_(node)
 {
   internal_state_enum_ = Internal_State::RESTING;
+
+  gripper_client_ =
+    node->create_client<pdf_beamtime_interfaces::srv::GripperControlMsg>("gripper_service");
+
 }
 
 moveit::core::MoveItErrorCode InnerStateMachine::move_robot(
@@ -21,9 +27,9 @@ moveit::core::MoveItErrorCode InnerStateMachine::move_robot(
         mgi.setJointValueTarget(joint_goal_);
         // Create a plan to that target pose
         auto const [planing_success, plan] = [&mgi] {
-            moveit::planning_interface::MoveGroupInterface::Plan msg;
-            auto const ok = static_cast<bool>(mgi.plan(msg));
-            return std::make_pair(ok, msg);
+            moveit::planning_interface::MoveGroupInterface::Plan plan;
+            auto const ok = static_cast<bool>(mgi.plan(plan));
+            return std::make_pair(ok, plan);
           }();
         if (planing_success) {
           // Change inner state to Moving if the robot is ready to move and not on clean up
@@ -49,14 +55,135 @@ moveit::core::MoveItErrorCode InnerStateMachine::move_robot(
   return return_error_code;
 }
 
+moveit::core::MoveItErrorCode InnerStateMachine::move_robot_cartesian(
+  moveit::planning_interface::MoveGroupInterface & mgi,
+  std::vector<geometry_msgs::msg::Pose> target_pose)
+{
+  moveit::core::MoveItErrorCode return_error_code = moveit::core::MoveItErrorCode::FAILURE;
+
+  switch (internal_state_enum_) {
+    case Internal_State::RESTING:
+    case Internal_State::CLEANUP: {
+        // Create a plan to that target pose
+        auto const [planing_success, plan] = [&mgi, target_pose] {
+            moveit::planning_interface::MoveGroupInterface::Plan plan;
+            // path_achieved_fraction, between 0.0 and 1.0, indicating the fraction of the path
+            // achieved as described by the waypoints. Return -1.0 in case of error.
+            double path_achieved_fraction = mgi.computeCartesianPath(
+              target_pose, 0.01, 0.0,
+              plan.trajectory_);
+            return std::make_pair(path_achieved_fraction, plan);
+          }();
+        if (1.0 - planing_success < 0.000001) {
+          // Change inner state to Moving if the robot is ready to move and not on clean up
+          if (internal_state_enum_ == Internal_State::RESTING) {
+            set_internal_state(Internal_State::MOVING);
+          }
+          auto exec_results = mgi.execute(plan);
+          return_error_code = exec_results;
+        } else {
+          return_error_code = moveit::core::MoveItErrorCode::FAILURE;
+        }
+      }
+      break;
+
+    default:
+      RCLCPP_ERROR(
+        node_->get_logger(), "Robot's current internal state is %s ",
+        internal_state_names[static_cast<int>(internal_state_enum_)].c_str());
+      return_error_code = moveit::core::MoveItErrorCode::FAILURE;
+      break;
+  }
+
+  return return_error_code;
+}
+
 moveit::core::MoveItErrorCode InnerStateMachine::close_gripper()
 {
-  return moveit::core::MoveItErrorCode::SUCCESS;
+
+  moveit::core::MoveItErrorCode return_error_code = moveit::core::MoveItErrorCode::FAILURE;
+
+  switch (internal_state_enum_) {
+    case Internal_State::RESTING:
+    case Internal_State::CLEANUP: {
+        auto request = std::make_shared<pdf_beamtime_interfaces::srv::GripperControlMsg::Request>();
+        request->command = "CLOSE";
+        request->grip = 100;
+
+        if (!gripper_client_->wait_for_service(10s)) {
+          return_error_code = moveit::core::MoveItErrorCode::FAILURE;
+          break;
+
+        } else {
+          set_internal_state(Internal_State::MOVING);
+          auto result = gripper_client_->async_send_request(request);
+          if (rclcpp::spin_until_future_complete(node_, result) ==
+            rclcpp::FutureReturnCode::SUCCESS)
+          {
+            RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "Gripper open: %d", result.get()->results);
+            return_error_code = moveit::core::MoveItErrorCode::SUCCESS;
+          } else {
+            RCLCPP_ERROR(rclcpp::get_logger("rclcpp"), "Failed to call service");
+            return_error_code = moveit::core::MoveItErrorCode::FAILURE;
+          }
+        }
+
+      }
+      break;
+
+    default:
+      RCLCPP_ERROR(
+        node_->get_logger(), "Robot's current internal state is %s ",
+        internal_state_names[static_cast<int>(internal_state_enum_)].c_str());
+      return_error_code = moveit::core::MoveItErrorCode::FAILURE;
+      break;
+  }
+
+  return return_error_code;
 }
 
 moveit::core::MoveItErrorCode InnerStateMachine::open_gripper()
 {
-  return moveit::core::MoveItErrorCode::SUCCESS;
+
+  moveit::core::MoveItErrorCode return_error_code = moveit::core::MoveItErrorCode::FAILURE;
+
+  switch (internal_state_enum_) {
+    case Internal_State::RESTING:
+    case Internal_State::CLEANUP: {
+        auto request = std::make_shared<pdf_beamtime_interfaces::srv::GripperControlMsg::Request>();
+        request->command = "OPEN";
+        request->grip = 100;
+
+        if (!gripper_client_->wait_for_service(10s)) {
+          return_error_code = moveit::core::MoveItErrorCode::FAILURE;
+          break;
+
+        } else {
+          set_internal_state(Internal_State::MOVING);
+          auto result = gripper_client_->async_send_request(request);
+          if (rclcpp::spin_until_future_complete(node_, result) ==
+            rclcpp::FutureReturnCode::SUCCESS)
+          {
+            RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "Gripper open: %d", result.get()->results);
+            return_error_code = moveit::core::MoveItErrorCode::SUCCESS;
+          } else {
+            RCLCPP_ERROR(rclcpp::get_logger("rclcpp"), "Failed to call service");
+            return_error_code = moveit::core::MoveItErrorCode::FAILURE;
+          }
+        }
+
+      }
+      break;
+
+    default:
+      RCLCPP_ERROR(
+        node_->get_logger(), "Robot's current internal state is %s ",
+        internal_state_names[static_cast<int>(internal_state_enum_)].c_str());
+      return_error_code = moveit::core::MoveItErrorCode::FAILURE;
+      break;
+  }
+
+  return return_error_code;
 }
 
 void InnerStateMachine::pause(moveit::planning_interface::MoveGroupInterface & mgi)

--- a/src/pdf_beamtime/src/inner_state_machine.cpp
+++ b/src/pdf_beamtime/src/inner_state_machine.cpp
@@ -13,7 +13,6 @@ InnerStateMachine::InnerStateMachine(
   // Create gripper client
   gripper_client_ =
     gripper_node_->create_client<pdf_beamtime_interfaces::srv::GripperControlMsg>("gripper_service");
-
 }
 
 moveit::core::MoveItErrorCode InnerStateMachine::move_robot(
@@ -114,7 +113,6 @@ moveit::core::MoveItErrorCode InnerStateMachine::close_gripper()
         if (!gripper_client_->wait_for_service(10s)) {
           return_error_code = moveit::core::MoveItErrorCode::FAILURE;
           break;
-
         } else {
           set_internal_state(Internal_State::MOVING);
           auto result = gripper_client_->async_send_request(request);
@@ -129,7 +127,6 @@ moveit::core::MoveItErrorCode InnerStateMachine::close_gripper()
             return_error_code = moveit::core::MoveItErrorCode::FAILURE;
           }
         }
-
       }
       break;
 
@@ -140,13 +137,11 @@ moveit::core::MoveItErrorCode InnerStateMachine::close_gripper()
       return_error_code = moveit::core::MoveItErrorCode::FAILURE;
       break;
   }
-
   return return_error_code;
 }
 
 moveit::core::MoveItErrorCode InnerStateMachine::open_gripper()
 {
-
   moveit::core::MoveItErrorCode return_error_code = moveit::core::MoveItErrorCode::FAILURE;
 
   switch (internal_state_enum_) {
@@ -159,10 +154,8 @@ moveit::core::MoveItErrorCode InnerStateMachine::open_gripper()
         if (!gripper_client_->wait_for_service(10s)) {
           return_error_code = moveit::core::MoveItErrorCode::FAILURE;
           break;
-
         } else {
           set_internal_state(Internal_State::MOVING);
-
           auto result = gripper_client_->async_send_request(request);
           if (rclcpp::spin_until_future_complete(gripper_node_, result) ==
             rclcpp::FutureReturnCode::SUCCESS)
@@ -175,7 +168,6 @@ moveit::core::MoveItErrorCode InnerStateMachine::open_gripper()
             return_error_code = moveit::core::MoveItErrorCode::FAILURE;
           }
         }
-
       }
       break;
 
@@ -186,7 +178,6 @@ moveit::core::MoveItErrorCode InnerStateMachine::open_gripper()
       return_error_code = moveit::core::MoveItErrorCode::FAILURE;
       break;
   }
-
   return return_error_code;
 }
 

--- a/src/pdf_beamtime/src/inner_state_machine.cpp
+++ b/src/pdf_beamtime/src/inner_state_machine.cpp
@@ -122,6 +122,7 @@ moveit::core::MoveItErrorCode InnerStateMachine::close_gripper()
             rclcpp::FutureReturnCode::SUCCESS)
           {
             RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "Gripper open: %d", result.get()->results);
+            std::this_thread::sleep_for(3s);
             return_error_code = moveit::core::MoveItErrorCode::SUCCESS;
           } else {
             RCLCPP_ERROR(rclcpp::get_logger("rclcpp"), "Failed to call service");
@@ -167,6 +168,7 @@ moveit::core::MoveItErrorCode InnerStateMachine::open_gripper()
             rclcpp::FutureReturnCode::SUCCESS)
           {
             RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "Gripper open: %d", result.get()->results);
+            std::this_thread::sleep_for(3s);
             return_error_code = moveit::core::MoveItErrorCode::SUCCESS;
           } else {
             RCLCPP_ERROR(rclcpp::get_logger("rclcpp"), "Failed to call service");

--- a/src/pdf_beamtime/src/inner_state_machine.cpp
+++ b/src/pdf_beamtime/src/inner_state_machine.cpp
@@ -12,7 +12,8 @@ InnerStateMachine::InnerStateMachine(
 
   // Create gripper client
   gripper_client_ =
-    gripper_node_->create_client<pdf_beamtime_interfaces::srv::GripperControlMsg>("gripper_service");
+    gripper_node_->create_client<pdf_beamtime_interfaces::srv::GripperControlMsg>(
+    "gripper_service");
 }
 
 moveit::core::MoveItErrorCode InnerStateMachine::move_robot(
@@ -100,9 +101,7 @@ moveit::core::MoveItErrorCode InnerStateMachine::move_robot_cartesian(
 
 moveit::core::MoveItErrorCode InnerStateMachine::close_gripper()
 {
-
   moveit::core::MoveItErrorCode return_error_code = moveit::core::MoveItErrorCode::FAILURE;
-
   switch (internal_state_enum_) {
     case Internal_State::RESTING:
     case Internal_State::CLEANUP: {

--- a/src/pdf_beamtime/src/pdf_beamtime_client.py
+++ b/src/pdf_beamtime/src/pdf_beamtime_client.py
@@ -19,20 +19,20 @@ class SimpleClient(Node):
         self._action_client = ActionClient(self, PickPlaceControlMsg, "pdf_beamtime_action_server")
         self._goal_handle = None
 
-    def send_goal(self):
+    def send_pickup_goal(self):
         """Send a working goal."""
         goal_msg = PickPlaceControlMsg.Goal()
 
         goal_msg.pickup_approach = [240.86, -63.96, 127.57, -61.50, 98.26, 180.0]
         goal_msg.pickup_approach = [x / 180 * math.pi for x in goal_msg.pickup_approach]
 
-        goal_msg.pickup = [236.97, -54.79, 108.08, -51.21, 94.39, 180.0]
+        goal_msg.pickup = [236.54, -52.75, 106.64, -51.82, 93.97, 180.0]
         goal_msg.pickup = [x / 180 * math.pi for x in goal_msg.pickup]
 
         goal_msg.place_approach = [54.55, -84.79, 120.92, -36.14, 51.53, 180.0]
         goal_msg.place_approach = [x / 180 * math.pi for x in goal_msg.place_approach]
 
-        goal_msg.place = [62.16, -70.19, 100.56, -30.42, 59.15, 180.0]
+        goal_msg.place = [62.15, -71.66, 98.75, -27.14, 59.13, 180.0]
         goal_msg.place = [x / 180 * math.pi for x in goal_msg.place]
 
         self._action_client.wait_for_server()
@@ -50,13 +50,33 @@ class SimpleClient(Node):
         self.get_logger().warn("********** Goal Canceling Now *********")
         self._goal_handle.cancel_goal_async()
 
+    def send_return_sample_goal(self):
+        """Send a working goal."""
+        goal_msg = PickPlaceControlMsg.Goal()
+
+        goal_msg.pickup_approach = [54.55, -84.79, 120.92, -36.14, 51.53, 180.0]
+        goal_msg.pickup_approach = [x / 180 * math.pi for x in goal_msg.pickup_approach]
+
+        goal_msg.pickup = [62.15, -71.66, 98.75, -27.14, 59.13, 180.0]
+        goal_msg.pickup = [x / 180 * math.pi for x in goal_msg.pickup]
+
+        goal_msg.place_approach = [240.86, -63.96, 127.57, -61.50, 98.26, 180.0]
+        goal_msg.place_approach = [x / 180 * math.pi for x in goal_msg.place_approach]
+
+        goal_msg.place = [236.54, -52.75, 106.64, -51.82, 93.97, 180.0]
+        goal_msg.place = [x / 180 * math.pi for x in goal_msg.place]
+
+        self._action_client.wait_for_server()
+        self._send_goal_future = self._action_client.send_goal_async(goal_msg, feedback_callback=self.feedback_callback)
+
 
 def main(args=None):
     """Python main."""
     rclpy.init(args=args)
 
     client = SimpleClient()
-    client.send_goal()
+    # client.send_pickup_goal()
+    client.send_return_sample_goal()
 
     rclpy.spin(client)
 

--- a/src/pdf_beamtime/src/pdf_beamtime_client.py
+++ b/src/pdf_beamtime/src/pdf_beamtime_client.py
@@ -22,36 +22,21 @@ class SimpleClient(Node):
     def send_goal(self):
         """Send a working goal."""
         goal_msg = PickPlaceControlMsg.Goal()
-        goal_msg.pickup_approach = [1.466, -2.042, -2.1293, -2.164, -0.105, 0.0]
-        goal_msg.pickup = [1.099, -2.234, -1.728, -2.339, -0.489, -0.035]
-        goal_msg.place_approach = [2.618, -2.356, -1.763, -2.216, -2.215, 0.0]
-        goal_msg.place = [2.618, -2.356, -1.663, -2.416, -2.215, 0.0]
+
+        goal_msg.pickup_approach = [240.86, -63.96, 127.57, -61.50, 98.26, 180.0]
+        goal_msg.pickup_approach = [x / 180 * math.pi for x in goal_msg.pickup_approach]
+
+        goal_msg.pickup = [236.97, -54.79, 108.08, -51.21, 94.39, 180.0]
+        goal_msg.pickup = [x / 180 * math.pi for x in goal_msg.pickup]
+
+        goal_msg.place_approach = [54.55, -84.79, 120.92, -36.14, 51.53, 180.0]
+        goal_msg.place_approach = [x / 180 * math.pi for x in goal_msg.place_approach]
+
+        goal_msg.place = [62.16, -70.19, 100.56, -30.42, 59.15, 180.0]
+        goal_msg.place = [x / 180 * math.pi for x in goal_msg.place]
 
         self._action_client.wait_for_server()
         self._send_goal_future = self._action_client.send_goal_async(goal_msg, feedback_callback=self.feedback_callback)
-
-    def send_incompatible_goal(self):
-        """Send a goal that gets rejected by the move group."""
-        goal_msg = PickPlaceControlMsg.Goal()
-        goal_msg.pickup_approach = [1.466, -2.042, -2.1293, -2.164, -0.105, 0.0]
-        goal_msg.pickup = [1.099, -2.234, -1.728, -2.339, -0.489, -0.035]
-        goal_msg.place_approach = [2.618, -2.356, -1.763, -2.216, -2.215, 0.0]
-        goal_msg.place = [2.618, -2.566, -1.7453, -2.025, -2.217, 0.0]
-
-        self._action_client.wait_for_server()
-        self._send_goal_future = self._action_client.send_goal_async(goal_msg, feedback_callback=self.feedback_callback)
-
-    def send_self_cancelling_goal(self):
-        """Send a goal that gets cancelled after 15 seconds."""
-        goal_msg = PickPlaceControlMsg.Goal()
-        goal_msg.pickup_approach = [1.466, -2.042, -2.1293, -2.164, -0.105, 0.0]
-        goal_msg.pickup = [1.099, -2.234, -1.728, -2.339, -0.489, -0.035]
-        goal_msg.place_approach = [2.618, -2.356, -1.763, -2.216, -2.215, 0.0]
-        goal_msg.place = [2.618, -2.356, -1.663, -2.416, -2.215, 0.0]
-
-        self._action_client.wait_for_server()
-        self._send_goal_future = self._action_client.send_goal_async(goal_msg, feedback_callback=self.feedback_callback)
-        self._send_goal_future.add_done_callback(self.goal_response_callback)
 
     def feedback_callback(self, feedback_msg):
         """Display the feedback."""
@@ -72,8 +57,6 @@ def main(args=None):
 
     client = SimpleClient()
     client.send_goal()
-    # client.send_incompatible_goal()
-    # client.send_self_cancelling_goal()
 
     rclpy.spin(client)
 

--- a/src/pdf_beamtime/src/pdf_beamtime_client.py
+++ b/src/pdf_beamtime/src/pdf_beamtime_client.py
@@ -23,16 +23,16 @@ class SimpleClient(Node):
         """Send a working goal."""
         goal_msg = PickPlaceControlMsg.Goal()
 
-        goal_msg.pickup_approach = [240.86, -63.96, 127.57, -61.50, 98.26, 180.0]
+        goal_msg.pickup_approach = [241.41, -59.73, 130.19, -68.36, 99.66, 180.0]
         goal_msg.pickup_approach = [x / 180 * math.pi for x in goal_msg.pickup_approach]
 
-        goal_msg.pickup = [236.54, -52.75, 106.64, -51.82, 93.97, 180.0]
+        goal_msg.pickup = [238.27, -50.99, 106.60, -53.53, 96.54, 180.0]
         goal_msg.pickup = [x / 180 * math.pi for x in goal_msg.pickup]
 
-        goal_msg.place_approach = [54.55, -84.79, 120.92, -36.14, 51.53, 180.0]
+        goal_msg.place_approach = [55.10, -51.78, 124.84, -73.16, 52.24, 180.0]
         goal_msg.place_approach = [x / 180 * math.pi for x in goal_msg.place_approach]
 
-        goal_msg.place = [62.15, -71.66, 98.75, -27.14, 59.13, 180.0]
+        goal_msg.place = [63.84, -43.13, 98.29, -55.25, 61.00, 180.0]
         goal_msg.place = [x / 180 * math.pi for x in goal_msg.place]
 
         self._action_client.wait_for_server()
@@ -54,16 +54,16 @@ class SimpleClient(Node):
         """Send a working goal."""
         goal_msg = PickPlaceControlMsg.Goal()
 
-        goal_msg.pickup_approach = [54.55, -84.79, 120.92, -36.14, 51.53, 180.0]
+        goal_msg.pickup_approach = [55.10, -51.78, 124.84, -73.16, 52.24, 180.0]
         goal_msg.pickup_approach = [x / 180 * math.pi for x in goal_msg.pickup_approach]
 
-        goal_msg.pickup = [62.15, -71.66, 98.75, -27.14, 59.13, 180.0]
+        goal_msg.pickup = [63.84, -43.13, 98.29, -55.25, 61.00, 180.0]
         goal_msg.pickup = [x / 180 * math.pi for x in goal_msg.pickup]
 
-        goal_msg.place_approach = [240.86, -63.96, 127.57, -61.50, 98.26, 180.0]
+        goal_msg.place_approach = [241.41, -59.73, 130.19, -68.36, 99.66, 180.0]
         goal_msg.place_approach = [x / 180 * math.pi for x in goal_msg.place_approach]
 
-        goal_msg.place = [236.54, -52.75, 106.64, -51.82, 93.97, 180.0]
+        goal_msg.place = [238.27, -50.99, 106.60, -53.53, 96.54, 180.0]
         goal_msg.place = [x / 180 * math.pi for x in goal_msg.place]
 
         self._action_client.wait_for_server()

--- a/src/pdf_beamtime/src/pdf_beamtime_fidpose_client.py
+++ b/src/pdf_beamtime/src/pdf_beamtime_fidpose_client.py
@@ -1,0 +1,88 @@
+"""Copyright 2023 Brookhaven National Laboratory BSD 3 Clause License. See LICENSE.txt for details."""
+
+import math
+import time
+
+import rclpy
+from rclpy.action import ActionClient
+from rclpy.node import Node
+
+from pdf_beamtime_interfaces.action import PickPlaceControlMsg
+
+
+class SimpleClient(Node):
+    """Send a simple goal request to the action server."""
+
+    def __init__(self):
+        """Python init."""
+        super().__init__("pdf_beamtime_client")
+        self._action_client = ActionClient(self, PickPlaceControlMsg, "pdf_beamtime_action_server")
+        self._goal_handle = None
+
+    def send_goal(self):
+        """Send a working goal."""
+        goal_msg = PickPlaceControlMsg.Goal()
+        goal_msg.pickup_approach = [293.24, -77.05, 119.62, -43.57, 199.87, 180.0]
+        goal_msg.pickup_approach = [x / 180 * math.pi for x in goal_msg.pickup_approach]
+
+        # goal_msg.pickup = [1.099, -2.234, -1.728, -2.339, -0.489, -0.035]
+        goal_msg.place_approach = [293.24, -77.05, 119.62, -43.57, 199.87, 180.0]
+        goal_msg.place_approach = [x / 180 * math.pi for x in goal_msg.place_approach]
+
+        # goal_msg.place = [2.618, -2.356, -1.663, -2.416, -2.215, 0.0]
+
+        self._action_client.wait_for_server()
+        self._send_goal_future = self._action_client.send_goal_async(goal_msg, feedback_callback=self.feedback_callback)
+
+    def send_incompatible_goal(self):
+        """Send a goal that gets rejected by the move group."""
+        goal_msg = PickPlaceControlMsg.Goal()
+        goal_msg.pickup_approach = [1.466, -2.042, -2.1293, -2.164, -0.105, 0.0]
+        goal_msg.pickup = [1.099, -2.234, -1.728, -2.339, -0.489, -0.035]
+        goal_msg.place_approach = [2.618, -2.356, -1.763, -2.216, -2.215, 0.0]
+        goal_msg.place = [2.618, -2.566, -1.7453, -2.025, -2.217, 0.0]
+
+        self._action_client.wait_for_server()
+        self._send_goal_future = self._action_client.send_goal_async(goal_msg, feedback_callback=self.feedback_callback)
+
+    def send_self_cancelling_goal(self):
+        """Send a goal that gets cancelled after 15 seconds."""
+        goal_msg = PickPlaceControlMsg.Goal()
+        goal_msg.pickup_approach = [1.466, -2.042, -2.1293, -2.164, -0.105, 0.0]
+        goal_msg.pickup = [1.099, -2.234, -1.728, -2.339, -0.489, -0.035]
+        goal_msg.place_approach = [2.618, -2.356, -1.763, -2.216, -2.215, 0.0]
+        goal_msg.place = [2.618, -2.356, -1.663, -2.416, -2.215, 0.0]
+
+        self._action_client.wait_for_server()
+        self._send_goal_future = self._action_client.send_goal_async(goal_msg, feedback_callback=self.feedback_callback)
+        self._send_goal_future.add_done_callback(self.goal_response_callback)
+
+    def feedback_callback(self, feedback_msg):
+        """Display the feedback."""
+        feedback = feedback_msg.feedback
+        self.get_logger().info("Completion percentage: {0} %".format(math.ceil(feedback.status * 100)))
+
+    def goal_response_callback(self, future):
+        """Send a cancellation after 15 seconds."""
+        self._goal_handle = future.result()
+        time.sleep(15.0)
+        self.get_logger().warn("********** Goal Canceling Now *********")
+        self._goal_handle.cancel_goal_async()
+
+
+def main(args=None):
+    """Python main."""
+    rclpy.init(args=args)
+
+    client = SimpleClient()
+    client.send_goal()
+    # client.send_incompatible_goal()
+    # client.send_self_cancelling_goal()
+
+    rclpy.spin(client)
+
+    client.destroy_node()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pdf_beamtime/src/pdf_beamtime_fidpose_client.py
+++ b/src/pdf_beamtime/src/pdf_beamtime_fidpose_client.py
@@ -25,11 +25,11 @@ class SimpleClient(Node):
         goal_msg.pickup_approach = [293.24, -77.05, 119.62, -43.57, 199.87, 180.0]
         goal_msg.pickup_approach = [x / 180 * math.pi for x in goal_msg.pickup_approach]
 
-        # goal_msg.pickup = [1.099, -2.234, -1.728, -2.339, -0.489, -0.035]
-        goal_msg.place_approach = [293.24, -77.05, 119.62, -43.57, 199.87, 180.0]
+        goal_msg.place_approach = [54.55, -84.79, 120.92, -36.14, 51.53, 180.0]
         goal_msg.place_approach = [x / 180 * math.pi for x in goal_msg.place_approach]
 
-        # goal_msg.place = [2.618, -2.356, -1.663, -2.416, -2.215, 0.0]
+        goal_msg.place = [62.16, -70.19, 100.56, -30.42, 59.15, 180.0]
+        goal_msg.place = [x / 180 * math.pi for x in goal_msg.place]
 
         self._action_client.wait_for_server()
         self._send_goal_future = self._action_client.send_goal_async(goal_msg, feedback_callback=self.feedback_callback)

--- a/src/pdf_beamtime/src/pdf_beamtime_fidpose_client.py
+++ b/src/pdf_beamtime/src/pdf_beamtime_fidpose_client.py
@@ -22,14 +22,12 @@ class SimpleClient(Node):
     def send_pickup_goal(self):
         """Send a working goal."""
         goal_msg = FidPoseControlMsg.Goal()
-        goal_msg.pickup_approach = [293.24, -77.05, 119.62, -43.57, 199.87, 180.0]
-        goal_msg.pickup_approach = [x / 180 * math.pi for x in goal_msg.pickup_approach]
 
-        goal_msg.place_approach = [55.10, -51.78, 124.84, -73.16, 52.24, 180.0]
-        goal_msg.place_approach = [x / 180 * math.pi for x in goal_msg.place_approach]
+        goal_msg.inbeam_approach = [55.10, -51.78, 124.84, -73.16, 52.24, 180.0]
+        goal_msg.inbeam_approach = [x / 180 * math.pi for x in goal_msg.inbeam_approach]
 
-        goal_msg.place = [63.84, -43.13, 98.29, -55.25, 61.00, 180.0]
-        goal_msg.place = [x / 180 * math.pi for x in goal_msg.place]
+        goal_msg.inbeam = [63.84, -43.13, 98.29, -55.25, 61.00, 180.0]
+        goal_msg.inbeam = [x / 180 * math.pi for x in goal_msg.inbeam]
 
         goal_msg.sample_return = False
 
@@ -40,14 +38,11 @@ class SimpleClient(Node):
         """Send a working goal."""
         goal_msg = FidPoseControlMsg.Goal()
 
-        goal_msg.pickup_approach = [55.10, -51.78, 124.84, -73.16, 52.24, 180.0]
-        goal_msg.pickup_approach = [x / 180 * math.pi for x in goal_msg.pickup_approach]
+        goal_msg.inbeam_approach = [55.10, -51.78, 124.84, -73.16, 52.24, 180.0]
+        goal_msg.inbeam_approach = [x / 180 * math.pi for x in goal_msg.inbeam_approach]
 
-        goal_msg.pickup = [63.84, -43.13, 98.29, -55.25, 61.00, 180.0]
-        goal_msg.pickup = [x / 180 * math.pi for x in goal_msg.pickup]
-
-        goal_msg.place_approach = [293.24, -77.05, 119.62, -43.57, 199.87, 180.0]
-        goal_msg.place_approach = [x / 180 * math.pi for x in goal_msg.place_approach]
+        goal_msg.inbeam = [63.84, -43.13, 98.29, -55.25, 61.00, 180.0]
+        goal_msg.inbeam = [x / 180 * math.pi for x in goal_msg.inbeam]
 
         goal_msg.sample_return = True
 
@@ -72,8 +67,8 @@ def main(args=None):
     rclpy.init(args=args)
 
     client = SimpleClient()
-    # client.send_pickup_goal()
-    client.send_retrun_sample_goal()
+    client.send_pickup_goal()
+    # client.send_retrun_sample_goal()
 
     rclpy.spin(client)
 

--- a/src/pdf_beamtime/src/pdf_beamtime_fidpose_client.py
+++ b/src/pdf_beamtime/src/pdf_beamtime_fidpose_client.py
@@ -7,7 +7,7 @@ import rclpy
 from rclpy.action import ActionClient
 from rclpy.node import Node
 
-from pdf_beamtime_interfaces.action import PickPlaceControlMsg
+from pdf_beamtime_interfaces.action import FidPoseControlMsg
 
 
 class SimpleClient(Node):
@@ -15,13 +15,13 @@ class SimpleClient(Node):
 
     def __init__(self):
         """Python init."""
-        super().__init__("pdf_beamtime_client")
-        self._action_client = ActionClient(self, PickPlaceControlMsg, "pdf_beamtime_action_server")
+        super().__init__("pdf_beamtime_fidpose_client")
+        self._action_client = ActionClient(self, FidPoseControlMsg, "pdf_beamtime_fidpose_action_server")
         self._goal_handle = None
 
-    def send_goal(self):
+    def send_pickup_goal(self):
         """Send a working goal."""
-        goal_msg = PickPlaceControlMsg.Goal()
+        goal_msg = FidPoseControlMsg.Goal()
         goal_msg.pickup_approach = [293.24, -77.05, 119.62, -43.57, 199.87, 180.0]
         goal_msg.pickup_approach = [x / 180 * math.pi for x in goal_msg.pickup_approach]
 
@@ -30,6 +30,26 @@ class SimpleClient(Node):
 
         goal_msg.place = [62.16, -70.19, 100.56, -30.42, 59.15, 180.0]
         goal_msg.place = [x / 180 * math.pi for x in goal_msg.place]
+
+        goal_msg.sample_return = False
+
+        self._action_client.wait_for_server()
+        self._send_goal_future = self._action_client.send_goal_async(goal_msg, feedback_callback=self.feedback_callback)
+
+    def send_retrun_sample_goal(self):
+        """Send a working goal."""
+        goal_msg = FidPoseControlMsg.Goal()
+
+        goal_msg.pickup_approach = [54.55, -84.79, 120.92, -36.14, 51.53, 180.0]
+        goal_msg.pickup_approach = [x / 180 * math.pi for x in goal_msg.pickup_approach]
+
+        goal_msg.pickup = [62.16, -70.19, 100.56, -30.42, 59.15, 180.0]
+        goal_msg.pickup = [x / 180 * math.pi for x in goal_msg.pickup]
+
+        goal_msg.place_approach = [293.24, -77.05, 119.62, -43.57, 199.87, 180.0]
+        goal_msg.place_approach = [x / 180 * math.pi for x in goal_msg.place_approach]
+
+        goal_msg.sample_return = True
 
         self._action_client.wait_for_server()
         self._send_goal_future = self._action_client.send_goal_async(goal_msg, feedback_callback=self.feedback_callback)
@@ -52,7 +72,8 @@ def main(args=None):
     rclpy.init(args=args)
 
     client = SimpleClient()
-    client.send_goal()
+    # client.send_pickup_goal()
+    client.send_retrun_sample_goal()
 
     rclpy.spin(client)
 

--- a/src/pdf_beamtime/src/pdf_beamtime_fidpose_client.py
+++ b/src/pdf_beamtime/src/pdf_beamtime_fidpose_client.py
@@ -34,29 +34,6 @@ class SimpleClient(Node):
         self._action_client.wait_for_server()
         self._send_goal_future = self._action_client.send_goal_async(goal_msg, feedback_callback=self.feedback_callback)
 
-    def send_incompatible_goal(self):
-        """Send a goal that gets rejected by the move group."""
-        goal_msg = PickPlaceControlMsg.Goal()
-        goal_msg.pickup_approach = [1.466, -2.042, -2.1293, -2.164, -0.105, 0.0]
-        goal_msg.pickup = [1.099, -2.234, -1.728, -2.339, -0.489, -0.035]
-        goal_msg.place_approach = [2.618, -2.356, -1.763, -2.216, -2.215, 0.0]
-        goal_msg.place = [2.618, -2.566, -1.7453, -2.025, -2.217, 0.0]
-
-        self._action_client.wait_for_server()
-        self._send_goal_future = self._action_client.send_goal_async(goal_msg, feedback_callback=self.feedback_callback)
-
-    def send_self_cancelling_goal(self):
-        """Send a goal that gets cancelled after 15 seconds."""
-        goal_msg = PickPlaceControlMsg.Goal()
-        goal_msg.pickup_approach = [1.466, -2.042, -2.1293, -2.164, -0.105, 0.0]
-        goal_msg.pickup = [1.099, -2.234, -1.728, -2.339, -0.489, -0.035]
-        goal_msg.place_approach = [2.618, -2.356, -1.763, -2.216, -2.215, 0.0]
-        goal_msg.place = [2.618, -2.356, -1.663, -2.416, -2.215, 0.0]
-
-        self._action_client.wait_for_server()
-        self._send_goal_future = self._action_client.send_goal_async(goal_msg, feedback_callback=self.feedback_callback)
-        self._send_goal_future.add_done_callback(self.goal_response_callback)
-
     def feedback_callback(self, feedback_msg):
         """Display the feedback."""
         feedback = feedback_msg.feedback
@@ -76,8 +53,6 @@ def main(args=None):
 
     client = SimpleClient()
     client.send_goal()
-    # client.send_incompatible_goal()
-    # client.send_self_cancelling_goal()
 
     rclpy.spin(client)
 

--- a/src/pdf_beamtime/src/pdf_beamtime_fidpose_client.py
+++ b/src/pdf_beamtime/src/pdf_beamtime_fidpose_client.py
@@ -25,10 +25,10 @@ class SimpleClient(Node):
         goal_msg.pickup_approach = [293.24, -77.05, 119.62, -43.57, 199.87, 180.0]
         goal_msg.pickup_approach = [x / 180 * math.pi for x in goal_msg.pickup_approach]
 
-        goal_msg.place_approach = [54.55, -84.79, 120.92, -36.14, 51.53, 180.0]
+        goal_msg.place_approach = [55.10, -51.78, 124.84, -73.16, 52.24, 180.0]
         goal_msg.place_approach = [x / 180 * math.pi for x in goal_msg.place_approach]
 
-        goal_msg.place = [62.16, -70.19, 100.56, -30.42, 59.15, 180.0]
+        goal_msg.place = [63.84, -43.13, 98.29, -55.25, 61.00, 180.0]
         goal_msg.place = [x / 180 * math.pi for x in goal_msg.place]
 
         goal_msg.sample_return = False
@@ -40,10 +40,10 @@ class SimpleClient(Node):
         """Send a working goal."""
         goal_msg = FidPoseControlMsg.Goal()
 
-        goal_msg.pickup_approach = [54.55, -84.79, 120.92, -36.14, 51.53, 180.0]
+        goal_msg.pickup_approach = [55.10, -51.78, 124.84, -73.16, 52.24, 180.0]
         goal_msg.pickup_approach = [x / 180 * math.pi for x in goal_msg.pickup_approach]
 
-        goal_msg.pickup = [62.16, -70.19, 100.56, -30.42, 59.15, 180.0]
+        goal_msg.pickup = [63.84, -43.13, 98.29, -55.25, 61.00, 180.0]
         goal_msg.pickup = [x / 180 * math.pi for x in goal_msg.pickup]
 
         goal_msg.place_approach = [293.24, -77.05, 119.62, -43.57, 199.87, 180.0]

--- a/src/pdf_beamtime/src/pdf_beamtime_fidpose_server.cpp
+++ b/src/pdf_beamtime/src/pdf_beamtime_fidpose_server.cpp
@@ -85,6 +85,8 @@ void PdfBeamtimeFidPoseServer::execute(
         if (pickup_pose_saved) {
           fsm_results = run_return_fsm(fidpose_goal);
         } else {
+          results->success = false;
+          goal_handle->abort(results);
           RCLCPP_ERROR(node_->get_logger(), "Pickup poses are not set!");
           return;
         }
@@ -574,53 +576,4 @@ void PdfBeamtimeFidPoseServer::execute_cleanup()
   reset_fsm();
   inner_state_machine_->set_internal_state(Internal_State::RESTING);
   RCLCPP_INFO(node_->get_logger(), "Cleanup is complete");
-}
-
-int main(int argc, char * argv[])
-{
-  rclcpp::init(argc, argv);
-
-  // Create a ROS logger for main scope
-  auto const logger = rclcpp::get_logger("hello_moveit");
-  using namespace std::chrono_literals;
-
-  // Create a node for synchronously grabbing params
-  auto parameter_client_node = rclcpp::Node::make_shared("param_client");
-  auto parent_parameters_client =
-    std::make_shared<rclcpp::SyncParametersClient>(parameter_client_node, "move_group");
-  // Boiler plate wait block
-  while (!parent_parameters_client->wait_for_service(1s)) {
-    if (!rclcpp::ok()) {
-      RCLCPP_ERROR(
-        logger, "Interrupted while waiting for the service. Exiting.");
-      return 0;
-    }
-    RCLCPP_INFO(logger, "move_group service not available, waiting again...");
-  }
-  // Get robot config parameters from parameter server
-  auto parameters = parent_parameters_client->get_parameters(
-    {"robot_description_semantic",
-      "robot_description"});
-
-  // Set node parameters using NodeOptions
-  rclcpp::NodeOptions node_options;
-  node_options.automatically_declare_parameters_from_overrides(true);
-  node_options.parameter_overrides(
-  {
-    {"robot_description_semantic", parameters[0].value_to_string()},
-    {"robot_description", parameters[1].value_to_string()}
-  });
-
-  rclcpp::executors::MultiThreadedExecutor executor;
-
-  auto beamtime_server = std::make_shared<PdfBeamtimeFidPoseServer>(
-    "ur_arm",
-    node_options);
-
-  executor.add_node(beamtime_server->getNodeBaseInterface());
-  executor.add_node(beamtime_server->getInterruptNodeBaseInterface());
-  executor.spin();
-
-  rclcpp::shutdown();
-  return 0;
 }

--- a/src/pdf_beamtime/src/pdf_beamtime_fidpose_server.cpp
+++ b/src/pdf_beamtime/src/pdf_beamtime_fidpose_server.cpp
@@ -1,0 +1,354 @@
+/*Copyright 2024 Brookhaven National Laboratory
+BSD 3 Clause License. See LICENSE.txt for details.*/
+#include <pdf_beamtime/pdf_beamtime_fidpose_server.hpp>
+
+PdfBeamtimeFidPoseServer::PdfBeamtimeFidPoseServer(
+  const std::string & move_group_name = "ur_manipulator",
+  const rclcpp::NodeOptions & options = rclcpp::NodeOptions(),
+  std::string action_name = "pdf_beamtime_action_server")
+: PdfBeamtimeServer(move_group_name, options, action_name)
+{
+  RCLCPP_INFO(node_->get_logger(), "Inside the derived constructor");
+
+}
+
+// void PdfBeamtimeFidPoseServer::handle_accepted(
+//   const std::shared_ptr<rclcpp_action::ServerGoalHandle<PickPlaceControlMsg>> goal_handle)
+// {
+//   using namespace std::placeholders;
+//   std::cout << " inside ovrd";
+//   // this needs to return quickly to avoid blocking the executor, so spin up a new thread
+//   std::thread{std::bind(&PdfBeamtimeFidPoseServer::temp, this, _1), goal_handle}.detach();
+//   RCLCPP_INFO(node_->get_logger(), "Inside the override");
+
+// }
+
+// void PdfBeamtimeFidPoseServer::temp(
+//   const std::shared_ptr<rclcpp_action::ServerGoalHandle<PickPlaceControlMsg>> goal_handle)
+// {
+//  ;
+//  RCLCPP_INFO(node_->get_logger(), "Inside the temp")
+// }
+
+moveit::core::MoveItErrorCode PdfBeamtimeFidPoseServer::run_fsm(
+  std::shared_ptr<const pdf_beamtime_interfaces::action::PickPlaceControlMsg_Goal> goal)
+{
+  RCLCPP_INFO(node_->get_logger(), "My new run fsm");
+}
+
+// moveit::core::MoveItErrorCode PdfBeamtimeFidPoseServer::run_fsm(
+//   std::shared_ptr<const pdf_beamtime_interfaces::action::PickPlaceControlMsg_Goal> goal)
+// {
+//   RCLCPP_INFO(
+//     node_->get_logger(), "Executing state %s",
+//     external_state_names_[static_cast<int>(current_state_)].c_str());
+//   moveit::core::MoveItErrorCode motion_results = moveit::core::MoveItErrorCode::FAILURE;
+//   switch (current_state_) {
+//     case State::HOME:
+//       // Moves the robot to pickup approach.
+//       // If success: change state, increment progress, reset internel state
+//       motion_results = inner_state_machine_->move_robot(
+//         move_group_interface_,
+//         goal->pickup_approach);
+//       if (motion_results == moveit::core::MoveItErrorCode::SUCCESS) {
+//         set_current_state(State::PICKUP_APPROACH);
+//         inner_state_machine_->set_internal_state(Internal_State::RESTING);
+//         progress_ = progress_ + 1.0;
+//       }
+//       break;
+
+//     case State::PICKUP_APPROACH:
+//       // Moves the robot to pickup.
+//       // If success: change state, increment progress, reset internel state
+//       motion_results = inner_state_machine_->move_robot(
+//         move_group_interface_,
+//         goal->pickup);
+//       if (motion_results == moveit::core::MoveItErrorCode::SUCCESS) {
+//         set_current_state(State::PICKUP);
+//         inner_state_machine_->set_internal_state(Internal_State::RESTING);
+//         progress_ = progress_ + 1.0;
+//       }
+//       break;
+
+//     case State::PICKUP:
+//       // Pick up object by closing gripper. If success: move to grasp success with progress.
+//       // if fails, move to grasp_failure
+//       if (this->gripper_present_) {
+//         motion_results = inner_state_machine_->close_gripper();
+//         if (motion_results == moveit::core::MoveItErrorCode::SUCCESS) {
+//           progress_ = progress_ + 1.0;
+//           set_current_state(State::GRASP_SUCCESS);
+//           inner_state_machine_->set_internal_state(Internal_State::RESTING);
+//         } else {
+//           set_current_state(State::GRASP_FAILURE);
+//           inner_state_machine_->set_internal_state(Internal_State::RESTING);
+//         }
+//       }
+//       break;
+
+//     case State::GRASP_SUCCESS:
+//       // Successfully grasped. Do pickup retreat
+//       motion_results = inner_state_machine_->move_robot(
+//         move_group_interface_,
+//         goal->pickup_approach);
+
+//       if (motion_results == moveit::core::MoveItErrorCode::SUCCESS) {
+//         set_current_state(State::PICKUP_RETREAT);
+//         inner_state_machine_->set_internal_state(Internal_State::RESTING);
+//         progress_ = progress_ + 1.0;
+//       }
+//       break;
+
+//     case State::GRASP_FAILURE:
+//       // Gripper did not close. failed. move to Pickup approach
+//       motion_results = inner_state_machine_->move_robot(
+//         move_group_interface_,
+//         goal->pickup_approach);
+//       if (motion_results == moveit::core::MoveItErrorCode::SUCCESS) {
+//         set_current_state(State::PICKUP_APPROACH);
+//         inner_state_machine_->set_internal_state(Internal_State::RESTING);
+//       }
+//       progress_ = progress_ - 1.0;
+//       break;
+
+//     case State::PICKUP_RETREAT:
+//       // Sample in hand. Move to place approach.
+//       motion_results = inner_state_machine_->move_robot(
+//         move_group_interface_,
+//         goal->place_approach);
+//       if (motion_results == moveit::core::MoveItErrorCode::SUCCESS) {
+//         set_current_state(State::PLACE_APPROACH);
+//         inner_state_machine_->set_internal_state(Internal_State::RESTING);
+//         progress_ = progress_ + 1.0;
+//       }
+//       break;
+
+//     case State::PLACE_APPROACH:
+//       // Move sample to place
+//       motion_results = inner_state_machine_->move_robot(
+//         move_group_interface_,
+//         goal->place);
+//       if (motion_results == moveit::core::MoveItErrorCode::SUCCESS) {
+//         set_current_state(State::PLACE);
+//         inner_state_machine_->set_internal_state(Internal_State::RESTING);
+//         progress_ = progress_ + 1.0;
+//       }
+//       break;
+
+//     case State::PLACE:
+//       // Place the sample.
+//       if (this->gripper_present_) {
+//         motion_results = inner_state_machine_->open_gripper();
+//         if (motion_results == moveit::core::MoveItErrorCode::SUCCESS) {
+//           progress_ = progress_ + 1.0;
+//           set_current_state(State::RELEASE_SUCCESS);
+//           inner_state_machine_->set_internal_state(Internal_State::RESTING);
+//         } else {
+//           set_current_state(State::RELEASE_FAILURE);
+//           inner_state_machine_->set_internal_state(Internal_State::RESTING);
+//         }
+//       }
+//       break;
+
+//     case State::RELEASE_SUCCESS:
+//       // Sample was successfully released.
+//       motion_results = inner_state_machine_->move_robot(
+//         move_group_interface_,
+//         goal->place_approach);
+//       if (motion_results == moveit::core::MoveItErrorCode::SUCCESS) {
+//         set_current_state(State::PLACE_RETREAT);
+//         inner_state_machine_->set_internal_state(Internal_State::RESTING);
+//         progress_ = progress_ + 1.0;
+//       }
+//       break;
+
+//     case State::PLACE_RETREAT:
+//       // Move back to rest/home position
+//       motion_results = inner_state_machine_->move_robot(
+//         move_group_interface_, goal_home_);
+//       if (motion_results == moveit::core::MoveItErrorCode::SUCCESS) {
+//         set_current_state(State::HOME);
+//         inner_state_machine_->set_internal_state(Internal_State::RESTING);
+//         progress_ = progress_ + 1.0;
+//       }
+//       break;
+
+//     default:
+//       break;
+//   }
+
+//   return motion_results;
+// }
+
+// bool PdfBeamtimeFidPoseServer::reset_fsm()
+// {
+//   bool reset_results = false;
+//   // This prevents the internal state reset while in clean up
+//   if (inner_state_machine_->get_internal_state() != Internal_State::CLEANUP) {
+//     inner_state_machine_->set_internal_state(Internal_State::RESTING);
+//   }
+//   auto motion_results = inner_state_machine_->move_robot(move_group_interface_, goal_home_);
+//   if (this->gripper_present_) {
+//     inner_state_machine_->open_gripper();
+//   }
+//   if (motion_results == moveit::core::MoveItErrorCode::SUCCESS) {
+//     set_current_state(State::HOME);
+//     reset_results = true;
+//     RCLCPP_INFO(node_->get_logger(), "State machine was RESET");
+//   } else {
+//     RCLCPP_INFO(node_->get_logger(), "State machine reset FAILED");
+//   }
+//   progress_ = 0.0;
+
+//   return reset_results;
+// }
+
+// moveit::core::MoveItErrorCode PdfBeamtimeFidPoseServer::return_sample()
+// {
+//   moveit::core::MoveItErrorCode motion_results = moveit::core::MoveItErrorCode::FAILURE;
+
+//   // Move to pickup approach
+//   motion_results = inner_state_machine_->move_robot(
+//     move_group_interface_,
+//     goal->pickup_approach);
+//   // Move to pick up
+//   motion_results = inner_state_machine_->move_robot(
+//     move_group_interface_,
+//     goal->pickup);
+//   // Open the gripper
+//   inner_state_machine_->open_gripper();
+//   // Move back to pickup approach
+//   motion_results = inner_state_machine_->move_robot(
+//     move_group_interface_,
+//     goal->pickup_approach);
+
+//   return motion_results;
+// }
+
+// void PdfBeamtimeFidPoseServer::handle_pause()
+// {
+//   RCLCPP_INFO(node_->get_logger(), "PAUSED command received");
+//   inner_state_machine_->pause(move_group_interface_);
+// }
+
+// void PdfBeamtimeFidPoseServer::handle_stop()
+// {
+//   RCLCPP_INFO(node_->get_logger(), "STOP command received");
+//   execute_cleanup();
+// }
+
+// void PdfBeamtimeFidPoseServer::execute_cleanup()
+// {
+//   inner_state_machine_->set_internal_state(Internal_State::CLEANUP);
+//   RCLCPP_INFO(node_->get_logger(), "Cleanup is in progress");
+
+//   switch (current_state_) {
+//     case State::GRASP_SUCCESS:
+//       inner_state_machine_->move_robot(move_group_interface_, goal->pickup);
+//       inner_state_machine_->open_gripper();
+//       inner_state_machine_->move_robot(move_group_interface_, goal->pickup_approach);
+//       break;
+
+//     case State::PICKUP_APPROACH:
+//       inner_state_machine_->move_robot(move_group_interface_, goal->pickup_approach);
+//       break;
+
+//     case State::PICKUP_RETREAT:
+//     case State::PLACE_APPROACH:
+//     case State::PLACE:
+//       return_sample();
+//       break;
+
+//     case State::PICKUP:
+//     case State::GRASP_FAILURE:
+//       inner_state_machine_->move_robot(move_group_interface_, goal->pickup_approach);
+//       break;
+
+//     case State::RELEASE_FAILURE:
+//     case State::RELEASE_SUCCESS:
+//       inner_state_machine_->move_robot(move_group_interface_, goal->place_approach);
+//       break;
+
+//     default:
+//       break;
+//   }
+//   reset_fsm();
+//   inner_state_machine_->set_internal_state(Internal_State::RESTING);
+//   RCLCPP_INFO(node_->get_logger(), "Cleanup is complete");
+// }
+
+// void PdfBeamtimeFidPoseServer::handle_abort()
+// {
+//   RCLCPP_INFO(node_->get_logger(), "ABORT command received");
+//   execute_cleanup();
+// }
+
+// void PdfBeamtimeFidPoseServer::handle_halt()
+// {
+//   RCLCPP_INFO(node_->get_logger(), "HALT command received");
+//   inner_state_machine_->halt(move_group_interface_);
+// }
+
+// void PdfBeamtimeFidPoseServer::handle_resume()
+// {
+//   RCLCPP_INFO(node_->get_logger(), "RESUME command received");
+//   inner_state_machine_->set_internal_state(Internal_State::RESTING);
+// }
+
+// void PdfBeamtimeFidPoseServer::set_current_state(State state)
+// {
+//   RCLCPP_INFO(
+//     node_->get_logger(), "[%s] Current state changed to %s.",
+//     external_state_names_[static_cast<int>(current_state_)].c_str(),
+//     external_state_names_[static_cast<int>(state)].c_str());
+//   current_state_ = state;
+// }
+
+int main(int argc, char * argv[])
+{
+  rclcpp::init(argc, argv);
+
+  // Create a ROS logger for main scope
+  auto const logger = rclcpp::get_logger("hello_moveit");
+  using namespace std::chrono_literals;
+
+  // Create a node for synchronously grabbing params
+  auto parameter_client_node = rclcpp::Node::make_shared("param_client");
+  auto parent_parameters_client =
+    std::make_shared<rclcpp::SyncParametersClient>(parameter_client_node, "move_group");
+  // Boiler plate wait block
+  while (!parent_parameters_client->wait_for_service(1s)) {
+    if (!rclcpp::ok()) {
+      RCLCPP_ERROR(
+        logger, "Interrupted while waiting for the service. Exiting.");
+      return 0;
+    }
+    RCLCPP_INFO(logger, "move_group service not available, waiting again...");
+  }
+  // Get robot config parameters from parameter server
+  auto parameters = parent_parameters_client->get_parameters(
+    {"robot_description_semantic",
+      "robot_description"});
+
+  // Set node parameters using NodeOptions
+  rclcpp::NodeOptions node_options;
+  node_options.automatically_declare_parameters_from_overrides(true);
+  node_options.parameter_overrides(
+  {
+    {"robot_description_semantic", parameters[0].value_to_string()},
+    {"robot_description", parameters[1].value_to_string()}
+  });
+
+  rclcpp::executors::MultiThreadedExecutor executor;
+
+  auto beamtime_server = std::make_shared<PdfBeamtimeFidPoseServer>(
+    "ur_arm",
+    node_options);
+
+  executor.add_node(beamtime_server->getNodeBaseInterface());
+  executor.add_node(beamtime_server->getInterruptNodeBaseInterface());
+  executor.spin();
+
+  rclcpp::shutdown();
+  return 0;
+}

--- a/src/pdf_beamtime/src/pdf_beamtime_fidpose_server.cpp
+++ b/src/pdf_beamtime/src/pdf_beamtime_fidpose_server.cpp
@@ -339,6 +339,14 @@ moveit::core::MoveItErrorCode PdfBeamtimeFidPoseServer::run_fsm(
         motion_results = inner_state_machine_->move_robot(
           move_group_interface_,
           pickup_approach_joints_);
+        if (motion_results == moveit::core::MoveItErrorCode::SUCCESS) {
+          inner_state_machine_->set_internal_state(Internal_State::RESTING);
+        } else {
+          break;
+        }
+        motion_results = inner_state_machine_->move_robot(
+          move_group_interface_,
+          goal->place_approach);
       }
       if (motion_results == moveit::core::MoveItErrorCode::SUCCESS) {
         set_current_state(State::PLACE_RETREAT);

--- a/src/pdf_beamtime/src/pdf_beamtime_server.cpp
+++ b/src/pdf_beamtime/src/pdf_beamtime_server.cpp
@@ -116,7 +116,6 @@ rclcpp_action::GoalResponse PdfBeamtimeServer::handle_goal(
   const rclcpp_action::GoalUUID & uuid,
   std::shared_ptr<const PickPlaceControlMsg::Goal> goal)
 {
-  RCLCPP_INFO(node_->get_logger(), "Inside base: handle goal");
   (void)uuid;
   return rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;
 }

--- a/src/pdf_beamtime/src/pdf_beamtime_server.cpp
+++ b/src/pdf_beamtime/src/pdf_beamtime_server.cpp
@@ -11,6 +11,7 @@ PdfBeamtimeServer::PdfBeamtimeServer(
   std::string action_name = "pdf_beamtime_action_server")
 : node_(std::make_shared<rclcpp::Node>("pdf_beamtime_server", options)),
   interrupt_node_(std::make_shared<rclcpp::Node>("interrupt_server")),
+  gripper_node_(std::make_shared<rclcpp::Node>("gripper_node_client")),
   move_group_interface_(node_, move_group_name),
   planning_scene_interface_()
 {
@@ -51,12 +52,13 @@ PdfBeamtimeServer::PdfBeamtimeServer(
   // Initialize to home
   current_state_ = State::HOME;
   gripper_present_ = node_->get_parameter("gripper_present").as_bool();
-  inner_state_machine_ = new InnerStateMachine(node_);
+  inner_state_machine_ = new InnerStateMachine(node_, gripper_node_);
 
   bluesky_interrupt_service_ = interrupt_node_->create_service<BlueskyInterruptMsg>(
     "bluesky_interrupt",
     std::bind(
       &PdfBeamtimeServer::bluesky_interrupt_cb, this, _1, _2));
+
 }
 
 void PdfBeamtimeServer::bluesky_interrupt_cb(

--- a/src/pdf_beamtime/src/pdf_beamtime_server.cpp
+++ b/src/pdf_beamtime/src/pdf_beamtime_server.cpp
@@ -1,4 +1,4 @@
-/*Copyright 2023 Brookhaven National Laboratory
+/*Copyright 2024 Brookhaven National Laboratory
 BSD 3 Clause License. See LICENSE.txt for details.*/
 #include <pdf_beamtime/pdf_beamtime_server.hpp>
 
@@ -116,6 +116,7 @@ rclcpp_action::GoalResponse PdfBeamtimeServer::handle_goal(
   const rclcpp_action::GoalUUID & uuid,
   std::shared_ptr<const PickPlaceControlMsg::Goal> goal)
 {
+  RCLCPP_INFO(node_->get_logger(), "Inside base: handle goal");
   (void)uuid;
   return rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;
 }
@@ -624,53 +625,4 @@ void PdfBeamtimeServer::set_current_state(State state)
     external_state_names_[static_cast<int>(current_state_)].c_str(),
     external_state_names_[static_cast<int>(state)].c_str());
   current_state_ = state;
-}
-
-int main(int argc, char * argv[])
-{
-  rclcpp::init(argc, argv);
-
-  // Create a ROS logger for main scope
-  auto const logger = rclcpp::get_logger("hello_moveit");
-  using namespace std::chrono_literals;
-
-  // Create a node for synchronously grabbing params
-  auto parameter_client_node = rclcpp::Node::make_shared("param_client");
-  auto parent_parameters_client =
-    std::make_shared<rclcpp::SyncParametersClient>(parameter_client_node, "move_group");
-  // Boiler plate wait block
-  while (!parent_parameters_client->wait_for_service(1s)) {
-    if (!rclcpp::ok()) {
-      RCLCPP_ERROR(
-        logger, "Interrupted while waiting for the service. Exiting.");
-      return 0;
-    }
-    RCLCPP_INFO(logger, "move_group service not available, waiting again...");
-  }
-  // Get robot config parameters from parameter server
-  auto parameters = parent_parameters_client->get_parameters(
-    {"robot_description_semantic",
-      "robot_description"});
-
-  // Set node parameters using NodeOptions
-  rclcpp::NodeOptions node_options;
-  node_options.automatically_declare_parameters_from_overrides(true);
-  node_options.parameter_overrides(
-  {
-    {"robot_description_semantic", parameters[0].value_to_string()},
-    {"robot_description", parameters[1].value_to_string()}
-  });
-
-  rclcpp::executors::MultiThreadedExecutor executor;
-
-  auto beamtime_server = std::make_shared<PdfBeamtimeServer>(
-    "ur_arm",
-    node_options);
-
-  executor.add_node(beamtime_server->getNodeBaseInterface());
-  executor.add_node(beamtime_server->getInterruptNodeBaseInterface());
-  executor.spin();
-
-  rclcpp::shutdown();
-  return 0;
 }

--- a/src/pdf_beamtime/src/pdf_beamtime_server.cpp
+++ b/src/pdf_beamtime/src/pdf_beamtime_server.cpp
@@ -58,7 +58,6 @@ PdfBeamtimeServer::PdfBeamtimeServer(
     "bluesky_interrupt",
     std::bind(
       &PdfBeamtimeServer::bluesky_interrupt_cb, this, _1, _2));
-
 }
 
 void PdfBeamtimeServer::bluesky_interrupt_cb(

--- a/src/pdf_beamtime/src/tf_utilities.cpp
+++ b/src/pdf_beamtime/src/tf_utilities.cpp
@@ -80,15 +80,12 @@ std::pair<double, double> TFUtilities::get_wrist_elbow_alignment(
 std::vector<geometry_msgs::msg::Pose> TFUtilities::get_pickup_action_z_adj(
   moveit::planning_interface::MoveGroupInterface & mgi)
 {
-
   // Define waypoints for Cartesian path
   std::vector<geometry_msgs::msg::Pose> waypoints;
-
   geometry_msgs::msg::TransformStamped transform_world_to_grasping_point;
   geometry_msgs::msg::TransformStamped transform_world_to_pickup_approach_point;
 
-  double x_dist_to_pickup_approach, y_dist_to_pickup_approach, z_dist_to_pickup_approach = 0.0;
-  double x_dist_to_sample = 0.0, y_dist_to_sample = 0.0, z_dist_to_sample = 0.0;
+  double z_dist_to_pickup_approach = 0.0;
 
   while (rclcpp::ok()) {
     try {
@@ -128,15 +125,12 @@ std::vector<geometry_msgs::msg::Pose> TFUtilities::get_pickup_action_z_adj(
 std::vector<geometry_msgs::msg::Pose> TFUtilities::get_pickup_action_pre_pickup(
   moveit::planning_interface::MoveGroupInterface & mgi)
 {
-
   // Define waypoints for Cartesian path
   std::vector<geometry_msgs::msg::Pose> waypoints;
-
   geometry_msgs::msg::TransformStamped transform_world_to_grasping_point;
   geometry_msgs::msg::TransformStamped transform_world_to_pickup_approach_point;
 
-  double x_dist_to_pickup_approach, y_dist_to_pickup_approach, z_dist_to_pickup_approach = 0.0;
-  double x_dist_to_sample = 0.0, y_dist_to_sample = 0.0, z_dist_to_sample = 0.0;
+  double x_dist_to_pickup_approach = 0.0, y_dist_to_pickup_approach = 0.0;
 
   while (rclcpp::ok()) {
     try {
@@ -191,19 +185,16 @@ std::vector<geometry_msgs::msg::Pose> TFUtilities::get_pickup_action_pickup(
 
   // Define waypoints for Cartesian path
   std::vector<geometry_msgs::msg::Pose> waypoints;
-
   geometry_msgs::msg::TransformStamped transform_world_to_sample;
   geometry_msgs::msg::TransformStamped transform_world_to_pickup_approach_point;
 
-  double x_dist_to_pickup_approach, y_dist_to_pickup_approach, z_dist_to_pickup_approach = 0.0;
-  double x_dist_to_sample = 0.0, y_dist_to_sample = 0.0, z_dist_to_sample = 0.0;
+  double x_dist_to_sample = 0.0, y_dist_to_sample = 0.0;
 
   while (rclcpp::ok()) {
     try {
 
       transform_world_to_sample =
         tf_buffer_->lookupTransform(world_frame, sample_frame, tf2::TimePointZero);
-
       transform_world_to_pickup_approach_point = tf_buffer_->lookupTransform(
         world_frame,
         pre_pickup_approach_point_frame,

--- a/src/pdf_beamtime/src/tf_utilities.cpp
+++ b/src/pdf_beamtime/src/tf_utilities.cpp
@@ -5,10 +5,30 @@ BSD 3 Clause License. See LICENSE.txt for details.*/
 
 TFUtilities::TFUtilities(
   const rclcpp::Node::SharedPtr node)
-: node_(node)
+: node_(node), tf_util_logger_(node_->get_logger().get_child("tf_util"))
 {
   tf_buffer_ = std::make_unique<tf2_ros::Buffer>(node_->get_clock());
   tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
+
+  parameters_client_ = std::make_shared<rclcpp::SyncParametersClient>(node_, "aruco_pose");
+
+  while (!parameters_client_->wait_for_service(std::chrono::seconds(1))) {
+    if (!rclcpp::ok()) {
+      RCLCPP_ERROR(tf_util_logger_, "Interrupted while waiting for the service. Exiting.");
+      return;
+    }
+    RCLCPP_INFO(tf_util_logger_, "Waiting for the parameters service to be available...");
+  }
+
+  sample_frame = parameters_client_->get_parameter<std::string>("sample_name");
+  pre_pickup_approach_point_frame = parameters_client_->get_parameter<std::string>(
+    "pre_pickup_location.name");
+
+  world_frame = "world";
+  grasping_point_on_gripper_frame = "grasping_point_link";
+  wrist_2_frame = "wrist_2_link";
+
+
 }
 
 
@@ -17,7 +37,117 @@ double TFUtilities::degreesToRadians(double degrees)
   return degrees * M_PI / 180.0;
 }
 
-double TFUtilities::get_elbow_alignment()
+std::pair<double, double> TFUtilities::get_wrist_elbow_alignment(
+  moveit::planning_interface::MoveGroupInterface & mgi)
 {
-  return 0.0;
+  tf2::Quaternion tf2_wrist_2_quaternion;
+  tf2::Quaternion tf2_sample_quaternion;
+
+  geometry_msgs::msg::TransformStamped transform_world_to_sample;
+  geometry_msgs::msg::TransformStamped transform_world_to_wrist_2;
+
+  double wrist_2_roll, wrist_2_pitch, wrist_2_yaw;
+  double sample_roll, sample_pitch, sample_yaw;
+
+  while (rclcpp::ok()) {
+    try {
+      transform_world_to_sample =
+        tf_buffer_->lookupTransform(world_frame, sample_frame, tf2::TimePointZero);
+      transform_world_to_wrist_2 =
+        tf_buffer_->lookupTransform(world_frame, wrist_2_frame, tf2::TimePointZero);
+
+      tf2::fromMsg(transform_world_to_wrist_2.transform.rotation, tf2_wrist_2_quaternion);
+      tf2::fromMsg(transform_world_to_sample.transform.rotation, tf2_sample_quaternion);
+
+      // // Convert tf2::Quaternion to RPY
+      tf2::Matrix3x3(tf2_wrist_2_quaternion).getRPY(wrist_2_roll, wrist_2_pitch, wrist_2_yaw);
+      tf2::Matrix3x3(tf2_sample_quaternion).getRPY(sample_roll, sample_pitch, sample_yaw);
+
+      break;
+    } catch (tf2::TransformException & ex) {
+    }
+  }
+
+  // Get current joint values
+  std::vector<double> joint_group_positions;
+  mgi.getCurrentState()->copyJointGroupPositions(
+    mgi.getCurrentState()->getRobotModel()->getJointModelGroup("ur_arm"),
+    joint_group_positions
+  );
+
+  return std::make_pair(
+    sample_yaw * 180 / M_PI,
+    (joint_group_positions[4] + wrist_2_yaw - sample_yaw) * 180 / M_PI);
+
+}
+
+
+std::vector<geometry_msgs::msg::Pose> TFUtilities::get_pickup_action_waypoints(
+  moveit::planning_interface::MoveGroupInterface & mgi)
+{
+
+  // Define waypoints for Cartesian path
+  std::vector<geometry_msgs::msg::Pose> waypoints;
+
+  geometry_msgs::msg::TransformStamped transform_world_to_sample;
+  geometry_msgs::msg::TransformStamped transform_world_to_grasping_point;
+  geometry_msgs::msg::TransformStamped transform_world_to_pickup_approach_point;
+
+  double x_dist_to_pickup_approach, y_dist_to_pickup_approach, z_dist_to_pickup_approach = 0.0;
+  double x_dist_to_sample = 0.0, y_dist_to_sample = 0.0, z_dist_to_sample = 0.0;
+
+  while (rclcpp::ok()) {
+    try {
+      transform_world_to_sample =
+        tf_buffer_->lookupTransform(world_frame, sample_frame, tf2::TimePointZero);
+
+      transform_world_to_grasping_point = tf_buffer_->lookupTransform(
+        world_frame,
+        grasping_point_on_gripper_frame,
+        tf2::TimePointZero);
+
+      transform_world_to_pickup_approach_point = tf_buffer_->lookupTransform(
+        world_frame,
+        pre_pickup_approach_point_frame,
+        tf2::TimePointZero);
+
+      x_dist_to_pickup_approach =
+        transform_world_to_pickup_approach_point.transform.translation.x -
+        transform_world_to_grasping_point.transform.translation.x;
+      y_dist_to_pickup_approach =
+        transform_world_to_pickup_approach_point.transform.translation.y -
+        transform_world_to_grasping_point.transform.translation.y;
+      z_dist_to_pickup_approach =
+        transform_world_to_pickup_approach_point.transform.translation.z -
+        (transform_world_to_grasping_point.transform.translation.z);
+
+      x_dist_to_sample = transform_world_to_sample.transform.translation.x -
+        transform_world_to_pickup_approach_point.transform.translation.x;
+      y_dist_to_sample = transform_world_to_sample.transform.translation.y -
+        transform_world_to_pickup_approach_point.transform.translation.y;
+      z_dist_to_sample = transform_world_to_sample.transform.translation.z -
+        transform_world_to_pickup_approach_point.transform.translation.z;
+
+      break;
+    } catch (tf2::TransformException & ex) {
+      RCLCPP_ERROR(
+        tf_util_logger_, "Could not transform %s to %s: %s",
+        grasping_point_on_gripper_frame.c_str(),
+        sample_frame.c_str(), ex.what());
+    }
+  }
+
+  geometry_msgs::msg::Pose target_pose = mgi.getCurrentPose().pose;
+  // Move 2 cm down in the z direction
+  target_pose.position.z += z_dist_to_pickup_approach;
+  target_pose.position.z += -0.02;
+
+  waypoints.push_back(target_pose);
+
+  target_pose.position.x += x_dist_to_sample;
+  target_pose.position.y += y_dist_to_sample;
+  waypoints.push_back(target_pose);
+
+  return waypoints;
+
 }

--- a/src/pdf_beamtime/src/tf_utilities.cpp
+++ b/src/pdf_beamtime/src/tf_utilities.cpp
@@ -75,11 +75,9 @@ std::pair<double, double> TFUtilities::get_wrist_elbow_alignment(
   );
 
   return std::make_pair(
-    sample_yaw * 180 / M_PI,
-    (joint_group_positions[4] + wrist_2_yaw - sample_yaw) * 180 / M_PI);
-
+    (joint_group_positions[4] + wrist_2_yaw - sample_yaw),
+    sample_yaw * 180 / M_PI);
 }
-
 
 std::vector<geometry_msgs::msg::Pose> TFUtilities::get_pickup_action_waypoints(
   moveit::planning_interface::MoveGroupInterface & mgi)

--- a/src/pdf_beamtime/src/tf_utilities.cpp
+++ b/src/pdf_beamtime/src/tf_utilities.cpp
@@ -1,0 +1,23 @@
+/*Copyright 2024 Brookhaven National Laboratory
+BSD 3 Clause License. See LICENSE.txt for details.*/
+#include <pdf_beamtime/tf_utilities.hpp>
+
+
+TFUtilities::TFUtilities(
+  const rclcpp::Node::SharedPtr node)
+: node_(node)
+{
+  tf_buffer_ = std::make_unique<tf2_ros::Buffer>(node_->get_clock());
+  tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
+}
+
+
+double TFUtilities::degreesToRadians(double degrees)
+{
+  return degrees * M_PI / 180.0;
+}
+
+double TFUtilities::get_elbow_alignment()
+{
+  return 0.0;
+}

--- a/src/pdf_beamtime/src/tf_utilities.cpp
+++ b/src/pdf_beamtime/src/tf_utilities.cpp
@@ -3,8 +3,7 @@ BSD 3 Clause License. See LICENSE.txt for details.*/
 #include <pdf_beamtime/tf_utilities.hpp>
 
 
-TFUtilities::TFUtilities(
-  const rclcpp::Node::SharedPtr node)
+TFUtilities::TFUtilities(const rclcpp::Node::SharedPtr node)
 : node_(node), tf_util_logger_(node_->get_logger().get_child("tf_util"))
 {
   tf_buffer_ = std::make_unique<tf2_ros::Buffer>(node_->get_clock());

--- a/src/pdf_beamtime/src/tf_utilities.cpp
+++ b/src/pdf_beamtime/src/tf_utilities.cpp
@@ -26,8 +26,6 @@ TFUtilities::TFUtilities(const rclcpp::Node::SharedPtr node)
   world_frame = "world";
   grasping_point_on_gripper_frame = "grasping_point_link";
   wrist_2_frame = "wrist_2_link";
-
-
 }
 
 
@@ -125,7 +123,6 @@ std::vector<geometry_msgs::msg::Pose> TFUtilities::get_pickup_action_z_adj(
   waypoints.push_back(target_pose);
 
   return waypoints;
-
 }
 
 std::vector<geometry_msgs::msg::Pose> TFUtilities::get_pickup_action_pre_pickup(
@@ -233,5 +230,4 @@ std::vector<geometry_msgs::msg::Pose> TFUtilities::get_pickup_action_pickup(
   waypoints.push_back(target_pose);
 
   return waypoints;
-
 }

--- a/src/pdf_beamtime/src/tf_utilities.cpp
+++ b/src/pdf_beamtime/src/tf_utilities.cpp
@@ -182,7 +182,6 @@ std::vector<geometry_msgs::msg::Pose> TFUtilities::get_pickup_action_pre_pickup(
 std::vector<geometry_msgs::msg::Pose> TFUtilities::get_pickup_action_pickup(
   moveit::planning_interface::MoveGroupInterface & mgi)
 {
-
   // Define waypoints for Cartesian path
   std::vector<geometry_msgs::msg::Pose> waypoints;
   geometry_msgs::msg::TransformStamped transform_world_to_sample;
@@ -192,7 +191,6 @@ std::vector<geometry_msgs::msg::Pose> TFUtilities::get_pickup_action_pickup(
 
   while (rclcpp::ok()) {
     try {
-
       transform_world_to_sample =
         tf_buffer_->lookupTransform(world_frame, sample_frame, tf2::TimePointZero);
       transform_world_to_pickup_approach_point = tf_buffer_->lookupTransform(

--- a/src/pdf_beamtime_interfaces/CMakeLists.txt
+++ b/src/pdf_beamtime_interfaces/CMakeLists.txt
@@ -12,6 +12,7 @@ find_package(rosidl_default_generators REQUIRED)
 # Generate interfaces for actions and services
 rosidl_generate_interfaces(${PROJECT_NAME}
   "action/PickPlaceControlMsg.action"
+  "action/FidPoseControlMsg.action"
   "srv/UpdateObstacleMsg.srv"
   "srv/DeleteObstacleMsg.srv"
   "srv/BoxObstacleMsg.srv"

--- a/src/pdf_beamtime_interfaces/action/FidPoseControlMsg.action
+++ b/src/pdf_beamtime_interfaces/action/FidPoseControlMsg.action
@@ -1,6 +1,8 @@
 float64[] pickup_approach
 float64[] place_approach
 float64[] place
+float64[] pickup
+bool sample_return
 ---
 bool success
 ---

--- a/src/pdf_beamtime_interfaces/action/FidPoseControlMsg.action
+++ b/src/pdf_beamtime_interfaces/action/FidPoseControlMsg.action
@@ -1,7 +1,5 @@
-float64[] pickup_approach
-float64[] place_approach
-float64[] place
-float64[] pickup
+float64[] inbeam_approach
+float64[] inbeam
 bool sample_return
 ---
 bool success

--- a/src/pdf_beamtime_interfaces/action/FidPoseControlMsg.action
+++ b/src/pdf_beamtime_interfaces/action/FidPoseControlMsg.action
@@ -1,0 +1,7 @@
+float64[] pickup_approach
+float64[] place_approach
+float64[] place
+---
+bool success
+---
+float64 status


### PR DESCRIPTION
This PR creates two modes of pdf_beamtime sample manipulations with two ROS executables.

**Node: pdf_beamtime_server**
 It takes four joint space coordinates [pickup approach, pickup, place approach, and place] for picking a sample from a predefined storage and placing it at predefined in-beam location. 

Run
`ros2 launch pdf_beamtime pdf_beamtime.launch.py ` to launch pdf_beamtime_server.  

Run 
`python3 src/pdf_beamtime/src/pdf_beamtime_client.py` to send action client for sample manipulation.

**pdf_beamtime_fidpose_server**
This takes three joint space coordinates and a boolean flag to indicate if it's for picking up the sample  [inbeam_approach, inbeam, sample_return] and uses the pose generated through aruco_pose node to estimate the pose of the sample holder. Expected behavior is below:

![fidpose_place](https://github.com/user-attachments/assets/3fb84f10-6791-464e-bef7-50c07457f583)

On return, it takes three joint space coordinates and a boolean flag to indicate if it's to return the sample   [inbeam_approach, inbeam, sample_return]   and uses the pose estimated in picking up the sample to place the sample at the storage. Expected behavior is below:

![fidpose_return](https://github.com/user-attachments/assets/050862bc-68a8-4c0a-a35e-92782a644631)

Run
`ros2 launch pdf_beamtime pdf_beamtime_fidpose_server.launch.py` to launch pdf_beamtime_fidpose_server.  

Run
`python3 src/pdf_beamtime/src/pdf_beamtime_fidpose_client.py` to send action client for sample manipulation.

