### PR TITLE
Humble multi aruco detection

### DIFF
--- a/src/aruco_pose/include/aruco_pose/aruco_pose.hpp
+++ b/src/aruco_pose/include/aruco_pose/aruco_pose.hpp
@@ -57,17 +57,10 @@ private:
   // This is the actual length/width of the printed tag
   double physical_marker_size_;   // height/width in meters
 
-  // Median filter related vars
-  std::shared_ptr<filters::MultiChannelFilterBase<double>> median_filter_ =
-    std::make_shared<filters::MultiChannelMedianFilter<double>>();
-
-  std::vector<double> median_filtered_rpyxyz;
-
+  // Median filters related vars
   std::unordered_map<int,
     std::shared_ptr<filters::MultiChannelFilterBase<double>>> median_filters_map_;
-
   std::unordered_map<int, std::vector<double>> median_filtered_rpyxyz_map_;
-
 
   /// @brief converts a rpy to a quaternion
   geometry_msgs::msg::Quaternion toQuaternion(double roll, double pitch, double yaw);

--- a/src/aruco_pose/include/aruco_pose/aruco_pose.hpp
+++ b/src/aruco_pose/include/aruco_pose/aruco_pose.hpp
@@ -16,6 +16,7 @@ BSD 3 Clause License. See LICENSE.txt for details.*/
 #include <cmath>
 #include <fstream>
 #include <vector>
+#include <unordered_map>
 
 #include <rclcpp/rclcpp.hpp>
 #include <opencv2/opencv.hpp>
@@ -61,6 +62,12 @@ private:
     std::make_shared<filters::MultiChannelMedianFilter<double>>();
 
   std::vector<double> median_filtered_rpyxyz;
+
+  std::unordered_map<int,
+    std::shared_ptr<filters::MultiChannelFilterBase<double>>> median_filters_map_;
+
+  std::unordered_map<int, std::vector<double>> median_filtered_rpyxyz_map_;
+
 
   /// @brief converts a rpy to a quaternion
   geometry_msgs::msg::Quaternion toQuaternion(double roll, double pitch, double yaw);

--- a/src/aruco_pose/src/aruco_pose.cpp
+++ b/src/aruco_pose/src/aruco_pose.cpp
@@ -128,7 +128,8 @@ void ArucoPose::image_raw_callback(
           RCLCPP_INFO(this->LOGGER, "New ID found : %d ", id);
           median_filters_map_[id] = std::make_shared<filters::MultiChannelMedianFilter<double>>();
 
-          // Configure the median filter. 6 refers to the number of channels in the multi-channel filter
+          // Configure the median filter. 6 refers to the number of
+          // channels in the multi-channel filter
           // Note: it is necessary to have/declare a parameter named 'number_of_observations'
           // in the parameter server.
           median_filters_map_[id]->configure(

--- a/src/aruco_pose/src/aruco_pose.cpp
+++ b/src/aruco_pose/src/aruco_pose.cpp
@@ -116,9 +116,7 @@ void ArucoPose::image_raw_callback(
 
   // Exclude instances where no markers are detected
   try {
-
     if (!markerIds_.empty()) {
-
       // rvecs: rotational vector
       // tvecs: translation vector
       std::vector<cv::Vec3d> rvecs, tvecs;
@@ -135,11 +133,8 @@ void ArucoPose::image_raw_callback(
 
         int id = markerIds_[i];
 
-        if (median_filters_map_.find(id) != median_filters_map_.end()) {
-
-        } else {
+        if (median_filters_map_.find(id) == median_filters_map_.end()) {
           RCLCPP_INFO(this->LOGGER, "New ID found : %d ", id);
-
           median_filters_map_.insert_or_assign(
             id,
             std::make_shared<filters::MultiChannelMedianFilter<double>>());
@@ -210,7 +205,6 @@ void ArucoPose::image_raw_callback(
 
         static_broadcaster_.sendTransform(transformStamped_pre_pickup);
         static_broadcaster_.sendTransform(transformStamped_tag);
-
       }
     }
 

--- a/src/pdf_beamtime/include/pdf_beamtime/pdf_beamtime_fidpose_server.hpp
+++ b/src/pdf_beamtime/include/pdf_beamtime/pdf_beamtime_fidpose_server.hpp
@@ -5,6 +5,7 @@ BSD 3 Clause License. See LICENSE.txt for details.*/
 #include <memory>
 #include <string>
 #include <vector>
+#include <unordered_map>
 
 #include <pdf_beamtime/pdf_beamtime_server.hpp>
 #include <pdf_beamtime/tf_utilities.hpp>
@@ -58,4 +59,8 @@ private:
   std::vector<double> pre_pickup_approach_joints_;
   std::vector<double> pickup_joints_;
   int sample_id = 0;
+
+  std::unordered_map<int, std::vector<double>> pickup_storage_map_;
+  std::unordered_map<int, std::vector<double>> pre_pickup_approach_storage_map_;
+
 };

--- a/src/pdf_beamtime/include/pdf_beamtime/pdf_beamtime_fidpose_server.hpp
+++ b/src/pdf_beamtime/include/pdf_beamtime/pdf_beamtime_fidpose_server.hpp
@@ -57,4 +57,5 @@ private:
   bool pickup_pose_saved = false;
   std::vector<double> pre_pickup_approach_joints_;
   std::vector<double> pickup_joints_;
+  int sample_id = 0;
 };

--- a/src/pdf_beamtime/include/pdf_beamtime/pdf_beamtime_fidpose_server.hpp
+++ b/src/pdf_beamtime/include/pdf_beamtime/pdf_beamtime_fidpose_server.hpp
@@ -62,5 +62,4 @@ private:
 
   std::unordered_map<int, std::vector<double>> pickup_storage_map_;
   std::unordered_map<int, std::vector<double>> pre_pickup_approach_storage_map_;
-
 };

--- a/src/pdf_beamtime/include/pdf_beamtime/tf_utilities.hpp
+++ b/src/pdf_beamtime/include/pdf_beamtime/tf_utilities.hpp
@@ -29,8 +29,8 @@ private:
 
   std::shared_ptr<rclcpp::SyncParametersClient> parameters_client_;
 
-  std::string world_frame, sample_frame, grasping_point_on_gripper_frame, wrist_2_frame,
-    pre_pickup_approach_point_frame;
+  std::string world_frame, grasping_point_on_gripper_frame, wrist_2_frame,
+    pre_pickup_approach_point_frame_suffix_;
 
 public:
   explicit TFUtilities(const rclcpp::Node::SharedPtr node);
@@ -39,14 +39,14 @@ public:
   double degreesToRadians(double degrees);
 
   std::pair<double, double> get_wrist_elbow_alignment(
-    moveit::planning_interface::MoveGroupInterface & mgi);
+    moveit::planning_interface::MoveGroupInterface & mgi, int sample_id);
 
   std::vector<geometry_msgs::msg::Pose> get_pickup_action_z_adj(
-    moveit::planning_interface::MoveGroupInterface & mgi);
+    moveit::planning_interface::MoveGroupInterface & mgi, int sample_id);
 
   std::vector<geometry_msgs::msg::Pose> get_pickup_action_pre_pickup(
-    moveit::planning_interface::MoveGroupInterface & mgi);
+    moveit::planning_interface::MoveGroupInterface & mgi, int sample_id);
 
   std::vector<geometry_msgs::msg::Pose> get_pickup_action_pickup(
-    moveit::planning_interface::MoveGroupInterface & mgi);
+    moveit::planning_interface::MoveGroupInterface & mgi, int sample_id);
 };

--- a/src/pdf_beamtime/src/pdf_beamtime_fidpose_client.py
+++ b/src/pdf_beamtime/src/pdf_beamtime_fidpose_client.py
@@ -33,15 +33,13 @@ class SimpleClient(Node):
         self._action_client.wait_for_server()
         self._send_goal_future = self._action_client.send_goal_async(goal_msg, feedback_callback=self.feedback_callback)
 
-    def send_retrun_sample_goal(self):
+    def send_return_sample_goal(self):
         """Send a working goal."""
         goal_msg = FidPoseControlMsg.Goal()
 
-        goal_msg.inbeam_approach = [55.10, -51.78, 124.84, -73.16, 52.24, 180.0]
-        goal_msg.inbeam_approach = [x / 180 * math.pi for x in goal_msg.inbeam_approach]
+        goal_msg.inbeam_approach = [x / 180 * math.pi for x in [55.10, -51.78, 124.84, -73.16, 52.24, 180.0]]
 
-        goal_msg.inbeam = [63.84, -43.13, 98.29, -55.25, 61.00, 180.0]
-        goal_msg.inbeam = [x / 180 * math.pi for x in goal_msg.inbeam]
+        goal_msg.inbeam = [x / 180 * math.pi for x in [63.84, -43.13, 98.29, -55.25, 61.00, 180.0]]
 
         goal_msg.sample_return = True
         goal_msg.sample_id = 150
@@ -68,7 +66,7 @@ def main(args=None):
 
     client = SimpleClient()
     # client.send_pickup_goal()
-    client.send_retrun_sample_goal()
+    client.send_return_sample_goal()
 
     rclpy.spin(client)
 

--- a/src/pdf_beamtime/src/pdf_beamtime_fidpose_client.py
+++ b/src/pdf_beamtime/src/pdf_beamtime_fidpose_client.py
@@ -23,13 +23,13 @@ class SimpleClient(Node):
         """Send a working goal."""
         goal_msg = FidPoseControlMsg.Goal()
 
-        goal_msg.inbeam_approach = [55.10, -51.78, 124.84, -73.16, 52.24, 180.0]
-        goal_msg.inbeam_approach = [x / 180 * math.pi for x in goal_msg.inbeam_approach]
+        goal_msg.inbeam_approach = [x / 180 * math.pi for x in [55.10, -51.78, 124.84, -73.16, 52.24, 180.0]]
 
-        goal_msg.inbeam = [63.84, -43.13, 98.29, -55.25, 61.00, 180.0]
-        goal_msg.inbeam = [x / 180 * math.pi for x in goal_msg.inbeam]
+        goal_msg.inbeam = [x / 180 * math.pi for x in [63.84, -43.13, 98.29, -55.25, 61.00, 180.0]]
 
         goal_msg.sample_return = False
+
+        goal_msg.sample_id = 150
 
         self._action_client.wait_for_server()
         self._send_goal_future = self._action_client.send_goal_async(goal_msg, feedback_callback=self.feedback_callback)
@@ -45,6 +45,7 @@ class SimpleClient(Node):
         goal_msg.inbeam = [x / 180 * math.pi for x in goal_msg.inbeam]
 
         goal_msg.sample_return = True
+        goal_msg.sample_id = 0
 
         self._action_client.wait_for_server()
         self._send_goal_future = self._action_client.send_goal_async(goal_msg, feedback_callback=self.feedback_callback)

--- a/src/pdf_beamtime/src/pdf_beamtime_fidpose_client.py
+++ b/src/pdf_beamtime/src/pdf_beamtime_fidpose_client.py
@@ -28,7 +28,6 @@ class SimpleClient(Node):
         goal_msg.inbeam = [x / 180 * math.pi for x in [63.84, -43.13, 98.29, -55.25, 61.00, 180.0]]
 
         goal_msg.sample_return = False
-
         goal_msg.sample_id = 150
 
         self._action_client.wait_for_server()
@@ -45,7 +44,7 @@ class SimpleClient(Node):
         goal_msg.inbeam = [x / 180 * math.pi for x in goal_msg.inbeam]
 
         goal_msg.sample_return = True
-        goal_msg.sample_id = 0
+        goal_msg.sample_id = 150
 
         self._action_client.wait_for_server()
         self._send_goal_future = self._action_client.send_goal_async(goal_msg, feedback_callback=self.feedback_callback)
@@ -68,8 +67,8 @@ def main(args=None):
     rclpy.init(args=args)
 
     client = SimpleClient()
-    client.send_pickup_goal()
-    # client.send_retrun_sample_goal()
+    # client.send_pickup_goal()
+    client.send_retrun_sample_goal()
 
     rclpy.spin(client)
 

--- a/src/pdf_beamtime/src/tf_utilities.cpp
+++ b/src/pdf_beamtime/src/tf_utilities.cpp
@@ -19,8 +19,7 @@ TFUtilities::TFUtilities(const rclcpp::Node::SharedPtr node)
     RCLCPP_INFO(tf_util_logger_, "Waiting for the parameters service to be available...");
   }
 
-  sample_frame = parameters_client_->get_parameter<std::string>("sample_name");
-  pre_pickup_approach_point_frame = parameters_client_->get_parameter<std::string>(
+  pre_pickup_approach_point_frame_suffix_ = parameters_client_->get_parameter<std::string>(
     "pre_pickup_location.name");
 
   world_frame = "world";
@@ -35,10 +34,14 @@ double TFUtilities::degreesToRadians(double degrees)
 }
 
 std::pair<double, double> TFUtilities::get_wrist_elbow_alignment(
-  moveit::planning_interface::MoveGroupInterface & mgi)
+  moveit::planning_interface::MoveGroupInterface & mgi, int sample_id)
 {
   tf2::Quaternion tf2_wrist_2_quaternion;
   tf2::Quaternion tf2_sample_quaternion;
+
+  std::string sample_frame = std::to_string(sample_id);
+  std::string pre_pickup_approach_point_frame = std::to_string(sample_id) + "_" +
+    pre_pickup_approach_point_frame_suffix_;
 
   geometry_msgs::msg::TransformStamped transform_world_to_sample;
   geometry_msgs::msg::TransformStamped transform_world_to_wrist_2;
@@ -78,13 +81,16 @@ std::pair<double, double> TFUtilities::get_wrist_elbow_alignment(
 }
 
 std::vector<geometry_msgs::msg::Pose> TFUtilities::get_pickup_action_z_adj(
-  moveit::planning_interface::MoveGroupInterface & mgi)
+  moveit::planning_interface::MoveGroupInterface & mgi, int sample_id)
 {
   // Define waypoints for Cartesian path
   std::vector<geometry_msgs::msg::Pose> waypoints;
   geometry_msgs::msg::TransformStamped transform_world_to_grasping_point;
   geometry_msgs::msg::TransformStamped transform_world_to_pickup_approach_point;
 
+  std::string sample_frame = std::to_string(sample_id);
+  std::string pre_pickup_approach_point_frame = std::to_string(sample_id) + "_" +
+    pre_pickup_approach_point_frame_suffix_;
   double z_dist_to_pickup_approach = 0.0;
 
   while (rclcpp::ok()) {
@@ -123,12 +129,16 @@ std::vector<geometry_msgs::msg::Pose> TFUtilities::get_pickup_action_z_adj(
 }
 
 std::vector<geometry_msgs::msg::Pose> TFUtilities::get_pickup_action_pre_pickup(
-  moveit::planning_interface::MoveGroupInterface & mgi)
+  moveit::planning_interface::MoveGroupInterface & mgi, int sample_id)
 {
   // Define waypoints for Cartesian path
   std::vector<geometry_msgs::msg::Pose> waypoints;
   geometry_msgs::msg::TransformStamped transform_world_to_grasping_point;
   geometry_msgs::msg::TransformStamped transform_world_to_pickup_approach_point;
+
+  std::string sample_frame = std::to_string(sample_id);
+  std::string pre_pickup_approach_point_frame = std::to_string(sample_id) + "_" +
+    pre_pickup_approach_point_frame_suffix_;
 
   double x_dist_to_pickup_approach = 0.0, y_dist_to_pickup_approach = 0.0;
 
@@ -180,12 +190,16 @@ std::vector<geometry_msgs::msg::Pose> TFUtilities::get_pickup_action_pre_pickup(
 }
 
 std::vector<geometry_msgs::msg::Pose> TFUtilities::get_pickup_action_pickup(
-  moveit::planning_interface::MoveGroupInterface & mgi)
+  moveit::planning_interface::MoveGroupInterface & mgi, int sample_id)
 {
   // Define waypoints for Cartesian path
   std::vector<geometry_msgs::msg::Pose> waypoints;
   geometry_msgs::msg::TransformStamped transform_world_to_sample;
   geometry_msgs::msg::TransformStamped transform_world_to_pickup_approach_point;
+
+  std::string sample_frame = std::to_string(sample_id);
+  std::string pre_pickup_approach_point_frame = std::to_string(sample_id) + "_" +
+    pre_pickup_approach_point_frame_suffix_;
 
   double x_dist_to_sample = 0.0, y_dist_to_sample = 0.0;
 

--- a/src/pdf_beamtime_interfaces/action/FidPoseControlMsg.action
+++ b/src/pdf_beamtime_interfaces/action/FidPoseControlMsg.action
@@ -1,6 +1,7 @@
 float64[] inbeam_approach
 float64[] inbeam
 bool sample_return
+int32 sample_id
 ---
 bool success
 ---


### PR DESCRIPTION
This draft PR adds the feature to detect multiple ArUco tags and add their poses to the transform server. These poses are uniquely identified by the ArUco tag ID. 

![transform tree](https://github.com/user-attachments/assets/72c0ab65-2d08-4daf-a92d-2501eec3b1d0)

The action server message now includes an additional field to select which sample holder to be picked up. Below is a sample video:
![select_pick_place](https://github.com/user-attachments/assets/b4ec7937-f2cb-4e0f-9b00-0c1486faa3f9)

On returning the sample holder, the user has the option to return to a different storage given that the sample holder has previously being pickup up. Below is the second part of the above video where the sample holder being return to a different location:
![return_to_another_pickup](https://github.com/user-attachments/assets/b9a2ba5e-d7dc-405d-ae3d-1fe478dae457)


