### PR TITLE
Wrist restriction

### DIFF
--- a/src/pdf_beamtime/config/joint_poses.yaml
+++ b/src/pdf_beamtime/config/joint_poses.yaml
@@ -1,6 +1,11 @@
 pdf_beamtime_server:
   ros__parameters:
-    home_angles: [-0.11536, -1.783732, 0.38816, -1.75492, 0.11484, 3.14159] #For real robot
+    home_angles: [0.0, -1.5708, 0.00, -1.5708, 0.0, 3.14159] #For real robot
     pickup_approach_angles: [4.089481, -0.987856, 2.167873, -1.174083, 0.899019, 3.141593]
     gripper_present: true
     joint_acc_vel_scaling_factor: 0.1
+    joint_constraints:
+      joint_name: 'wrist_3_joint'
+      joint_position: 3.14159
+      upper_limit: 0.78539
+      lower_limit: 0.78539

--- a/src/pdf_beamtime/src/pdf_beamtime_server.cpp
+++ b/src/pdf_beamtime/src/pdf_beamtime_server.cpp
@@ -58,6 +58,19 @@ PdfBeamtimeServer::PdfBeamtimeServer(
     "bluesky_interrupt",
     std::bind(
       &PdfBeamtimeServer::bluesky_interrupt_cb, this, _1, _2));
+
+  //define constraints to restrict wrist movement
+  moveit_msgs::msg::JointConstraint jc;
+  jc.joint_name = node_->get_parameter("joint_constraints.joint_name").as_string();
+  jc.position = node_->get_parameter("joint_constraints.joint_position").as_double();
+  jc.tolerance_above = node_->get_parameter("joint_constraints.upper_limit").as_double();
+  jc.tolerance_below = node_->get_parameter("joint_constraints.lower_limit").as_double();
+  jc.weight = 1.0;
+
+  moveit_msgs::msg::Constraints constraints_;
+  constraints_.joint_constraints.push_back(jc);
+  move_group_interface_.setPathConstraints(constraints_);
+
 }
 
 void PdfBeamtimeServer::bluesky_interrupt_cb(

--- a/src/pdf_beamtime/src/pdf_beamtime_server.cpp
+++ b/src/pdf_beamtime/src/pdf_beamtime_server.cpp
@@ -59,7 +59,7 @@ PdfBeamtimeServer::PdfBeamtimeServer(
     std::bind(
       &PdfBeamtimeServer::bluesky_interrupt_cb, this, _1, _2));
 
-  //define constraints to restrict wrist movement
+  // define constraints to restrict wrist movement
   moveit_msgs::msg::JointConstraint jc;
   jc.joint_name = node_->get_parameter("joint_constraints.joint_name").as_string();
   jc.position = node_->get_parameter("joint_constraints.joint_position").as_double();
@@ -70,7 +70,6 @@ PdfBeamtimeServer::PdfBeamtimeServer(
   moveit_msgs::msg::Constraints constraints_;
   constraints_.joint_constraints.push_back(jc);
   move_group_interface_.setPathConstraints(constraints_);
-
 }
 
 void PdfBeamtimeServer::bluesky_interrupt_cb(


### PR DESCRIPTION
This PR adds a set of parameters to restrict the movement of the wrist_3_joint ( to which the gripper is connected) . Desired wrist position is 180 agrees in rotation. 

Note: Limiting the wrist movement further constraints the robot path planning, and the set of unreachable states will increase.