### PR TITLE
Refactor: remove while loops

### DIFF
--- a/src/pdf_beamtime/include/pdf_beamtime/tf_utilities.hpp
+++ b/src/pdf_beamtime/include/pdf_beamtime/tf_utilities.hpp
@@ -12,6 +12,7 @@ BSD 3 Clause License. See LICENSE.txt for details.*/
 #include <string>
 #include <memory>
 #include <vector>
+#include <chrono>
 #include <utility>
 
 #include <geometry_msgs/msg/transform_stamped.hpp>

--- a/src/pdf_beamtime/src/tf_utilities.cpp
+++ b/src/pdf_beamtime/src/tf_utilities.cpp
@@ -2,6 +2,7 @@
 BSD 3 Clause License. See LICENSE.txt for details.*/
 #include <pdf_beamtime/tf_utilities.hpp>
 
+using namespace std::chrono_literals;
 
 TFUtilities::TFUtilities(const rclcpp::Node::SharedPtr node)
 : node_(node), tf_util_logger_(node_->get_logger().get_child("tf_util"))
@@ -39,15 +40,9 @@ geometry_msgs::msg::TransformStamped TFUtilities::get_sample_pose(int sample_id)
   std::string sample_frame = std::to_string(sample_id);
   std::string pre_pickup_approach_point_frame = std::to_string(sample_id) + "_" +
     pre_pickup_approach_point_frame_suffix_;
-  while (rclcpp::ok()) {
-    try {
-      sample_pose =
-        tf_buffer_->lookupTransform(world_frame, sample_frame, tf2::TimePointZero);
 
-      break;
-    } catch (tf2::TransformException & ex) {
-    }
-  }
+  sample_pose =
+    tf_buffer_->lookupTransform(world_frame, sample_frame, tf2::TimePointZero, 10s);
 
   return sample_pose;
 }
@@ -59,17 +54,11 @@ geometry_msgs::msg::TransformStamped TFUtilities::get_sample_pre_pickup_pose(int
   std::string sample_frame = std::to_string(sample_id);
   std::string pre_pickup_approach_point_frame = std::to_string(sample_id) + "_" +
     pre_pickup_approach_point_frame_suffix_;
-  while (rclcpp::ok()) {
-    try {
-      pre_pickup_pose =
-        tf_buffer_->lookupTransform(
-        world_frame, pre_pickup_approach_point_frame,
-        tf2::TimePointZero);
 
-      break;
-    } catch (tf2::TransformException & ex) {
-    }
-  }
+  pre_pickup_pose =
+    tf_buffer_->lookupTransform(
+    world_frame, pre_pickup_approach_point_frame,
+    tf2::TimePointZero, 10s);
 
   return pre_pickup_pose;
 }
@@ -88,22 +77,15 @@ std::pair<double, double> TFUtilities::get_wrist_elbow_alignment(
   double wrist_2_roll, wrist_2_pitch, wrist_2_yaw;
   double sample_roll, sample_pitch, sample_yaw;
 
-  while (rclcpp::ok()) {
-    try {
-      transform_world_to_wrist_2 =
-        tf_buffer_->lookupTransform(world_frame, wrist_2_frame, tf2::TimePointZero);
+  transform_world_to_wrist_2 =
+    tf_buffer_->lookupTransform(world_frame, wrist_2_frame, tf2::TimePointZero, 10s);
 
-      tf2::fromMsg(transform_world_to_wrist_2.transform.rotation, tf2_wrist_2_quaternion);
-      tf2::fromMsg(transform_world_to_sample.transform.rotation, tf2_sample_quaternion);
+  tf2::fromMsg(transform_world_to_wrist_2.transform.rotation, tf2_wrist_2_quaternion);
+  tf2::fromMsg(transform_world_to_sample.transform.rotation, tf2_sample_quaternion);
 
-      // // Convert tf2::Quaternion to RPY
-      tf2::Matrix3x3(tf2_wrist_2_quaternion).getRPY(wrist_2_roll, wrist_2_pitch, wrist_2_yaw);
-      tf2::Matrix3x3(tf2_sample_quaternion).getRPY(sample_roll, sample_pitch, sample_yaw);
-
-      break;
-    } catch (tf2::TransformException & ex) {
-    }
-  }
+  // // Convert tf2::Quaternion to RPY
+  tf2::Matrix3x3(tf2_wrist_2_quaternion).getRPY(wrist_2_roll, wrist_2_pitch, wrist_2_yaw);
+  tf2::Matrix3x3(tf2_sample_quaternion).getRPY(sample_roll, sample_pitch, sample_yaw);
 
   // Get current joint values
   std::vector<double> joint_group_positions;
@@ -128,33 +110,25 @@ std::vector<geometry_msgs::msg::Pose> TFUtilities::get_pickup_action_z_adj(
 
   double z_dist_to_pickup_approach = 0.0;
 
-  while (rclcpp::ok()) {
-    try {
-      transform_world_to_grasping_point = tf_buffer_->lookupTransform(
-        world_frame,
-        grasping_point_on_gripper_frame,
-        tf2::TimePointZero);
+  try {
+    transform_world_to_grasping_point = tf_buffer_->lookupTransform(
+      world_frame,
+      grasping_point_on_gripper_frame,
+      tf2::TimePointZero, 10s);
 
-      z_dist_to_pickup_approach =
-        transform_world_to_sample.transform.translation.z -
-        (transform_world_to_grasping_point.transform.translation.z);
+    z_dist_to_pickup_approach =
+      transform_world_to_sample.transform.translation.z -
+      (transform_world_to_grasping_point.transform.translation.z);
 
-      break;
-    } catch (tf2::TransformException & ex) {
-      RCLCPP_ERROR(
-        tf_util_logger_, "Could not transform %s to %s: %s",
-        world_frame.c_str(), grasping_point_on_gripper_frame.c_str(),
-        ex.what());
-    }
+    geometry_msgs::msg::Pose target_pose = mgi.getCurrentPose().pose;
+    // Move 2 cm down in the z direction
+    target_pose.position.z += z_dist_to_pickup_approach;
+    target_pose.position.z += -0.02;
+
+    waypoints.push_back(target_pose);
+  } catch (const std::exception & e) {
+    RCLCPP_ERROR(tf_util_logger_, e.what());
   }
-
-  geometry_msgs::msg::Pose target_pose = mgi.getCurrentPose().pose;
-  // Move 2 cm down in the z direction
-  target_pose.position.z += z_dist_to_pickup_approach;
-  target_pose.position.z += -0.02;
-
-  waypoints.push_back(target_pose);
-
   return waypoints;
 }
 
@@ -169,28 +143,17 @@ std::vector<geometry_msgs::msg::Pose> TFUtilities::get_pickup_action_pre_pickup(
 
   double x_dist_to_pickup_approach = 0.0, y_dist_to_pickup_approach = 0.0;
 
-  while (rclcpp::ok()) {
-    try {
-      transform_world_to_grasping_point = tf_buffer_->lookupTransform(
-        world_frame,
-        grasping_point_on_gripper_frame,
-        tf2::TimePointZero);
+  transform_world_to_grasping_point = tf_buffer_->lookupTransform(
+    world_frame,
+    grasping_point_on_gripper_frame,
+    tf2::TimePointZero, 10s);
 
-      x_dist_to_pickup_approach =
-        transform_world_to_pickup_approach_point.transform.translation.x -
-        transform_world_to_grasping_point.transform.translation.x;
-      y_dist_to_pickup_approach =
-        transform_world_to_pickup_approach_point.transform.translation.y -
-        transform_world_to_grasping_point.transform.translation.y;
-
-      break;
-    } catch (tf2::TransformException & ex) {
-      RCLCPP_ERROR(
-        tf_util_logger_, "Could not transform %s to %s: %s",
-        world_frame.c_str(),
-        grasping_point_on_gripper_frame.c_str(), ex.what());
-    }
-  }
+  x_dist_to_pickup_approach =
+    transform_world_to_pickup_approach_point.transform.translation.x -
+    transform_world_to_grasping_point.transform.translation.x;
+  y_dist_to_pickup_approach =
+    transform_world_to_pickup_approach_point.transform.translation.y -
+    transform_world_to_grasping_point.transform.translation.y;
 
   geometry_msgs::msg::Pose target_pose = mgi.getCurrentPose().pose;
   target_pose.position.x += x_dist_to_pickup_approach;


### PR DESCRIPTION
This PR removes while loops form tf_utilities.cpp. They were added as a ready check for the lookupTransfrom function, but removed as the function lookupTransfrom itself provides the ready check functionality. 