### PR TITLE
CI: Harden GHA configuration

### DIFF
--- a/.github/workflows/ros.yaml
+++ b/.github/workflows/ros.yaml
@@ -1,4 +1,6 @@
 name: ROS C++ Testing and Linting
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/ros.yaml
+++ b/.github/workflows/ros.yaml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Test
         uses: ./.github/actions/test/
 
@@ -27,6 +29,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Run linter
         uses: ./.github/actions/lint/
         env:

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           persist-credentials: false
       - uses: actions/setup-python@v5
-      - uses: astral-sh/ruff-action@v3
+      - uses: astral-sh/ruff-action@eaf0ecdd668ceea36159ff9d91882c9795d89b49 # v3
       - name: Ruff Check
         run: ruff check --fix
       - name: Ruff Format

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v5
       - uses: astral-sh/ruff-action@v3
       - name: Ruff Check

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,4 +1,6 @@
 name: Check Code Style - Ruff
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -5,6 +5,8 @@
 # For more information, see:
 # https://github.com/github/super-linter
 name: Lint Code Base (Super-Linter)
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -18,8 +18,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          # Full git history is needed to get a proper list of changed files within `super-linter`
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Lint Code Base
         uses: github/super-linter@v7


### PR DESCRIPTION
Apply recommended hardening steps including:

- pinning to a SHA any actions used
- not persisting the read token on checkout
- setting the default permissions to read-only
