### PR TITLE
Switch to upstream epick driver, fix build issue from epick

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,9 @@ target/
 
 #Pixi
 pixi.lock
+
+# End effector drivers (imported via vcs)
+src/end_effectors/serial/
+src/end_effectors/robotiq_hande_driver/
+src/end_effectors/robotiq_hande_description/
+src/end_effectors/ros2_epick_gripper/

--- a/src/end_effectors/README.md
+++ b/src/end_effectors/README.md
@@ -14,9 +14,17 @@ This pulls in:
 - `serial` - ROS2 serial communication
 - `robotiq_hande_driver` - Robotiq HandE gripper driver
 - `robotiq_hande_description` - Robotiq HandE URDF models
-- `ros2_epick_gripper` - EPick vacuum gripper driver 
+- `ros2_epick_gripper` - EPick vacuum gripper driver
 
-**Note:** The EPick driver uses a fork from https://github.com/bondada-a/ros2_epick_gripper.git instead of the upstream PickNikRobotics version. This fork includes updated headers and removes the epick_moveit_studio package (requires Moveit Pro).
+**Note:** The `ros2_epick_gripper` repository includes `epick_moveit_studio` which depends on paywalled MoveIt Studio/MoveIt Pro packages. Since we don't use this package, skip it during build and dependency installation:
+
+```bash
+# Install dependencies
+rosdep install --from-paths src --ignore-src -y --skip-keys moveit_studio_behavior_interface
+
+# Build workspace (skip epick_moveit_studio)
+colcon build --packages-skip epick_moveit_studio
+```
 
 ## EPick Configuration
 

--- a/src/end_effectors/end_effectors.repos
+++ b/src/end_effectors/end_effectors.repos
@@ -13,5 +13,5 @@ repositories:
     version: humble-devel
   ros2_epick_gripper:
     type: git
-    url: https://github.com/bondada-a/ros2_epick_gripper.git
+    url: https://github.com/PickNikRobotics/ros2_epick_gripper.git
     version: main

--- a/src/end_effectors/epick_config/package.xml
+++ b/src/end_effectors/epick_config/package.xml
@@ -4,7 +4,7 @@
   <name>epick_config</name>
   <version>0.1.0</version>
   <description>Overlay configuration for ros2_epick_gripper (pose and serial port).</description>
-  <maintainer email="abondada@bnl.gov">Aditya Bondada</maintainer>
+  <maintainer email="aditya@example.com">Aditya</maintainer>
   <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
@@ -14,7 +14,7 @@
   <exec_depend>ros2run</exec_depend>
   <exec_depend>ros2param</exec_depend>
   <exec_depend>rclcpp</exec_depend>
-  <exec_depend>epick_description</exec_depend>
+
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/src/end_effectors/epick_config/package.xml
+++ b/src/end_effectors/epick_config/package.xml
@@ -4,7 +4,7 @@
   <name>epick_config</name>
   <version>0.1.0</version>
   <description>Overlay configuration for ros2_epick_gripper (pose and serial port).</description>
-  <maintainer email="aditya@example.com">Aditya</maintainer>
+  <maintainer email="abondada@bnl.gov">Aditya Bondada</maintainer>
   <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>


### PR DESCRIPTION
- removed epick_description exec depend in package.xml for epick_config.
- Use upstream branch for epick driver.
- Add build instructions for skipping paywalled package , closes #71 
- Add end_effector packages to gitignore (instead of having empty directories)
